### PR TITLE
Configured checkstyle with gradle and travis  #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ fabric.properties
 
 # *.iml
 # modules.xml
-# .idea/misc.xml
+.idea/misc.xml
 # *.ipr
 
 # Sonarlint plugin
@@ -135,3 +135,7 @@ gradle-app.setting
 **/build/
 
 # End of https://www.gitignore.io/api/java,gradle,intellij
+
+.idea/vcs.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     token: $SONARCLOUD_TOKEN
 script:
   - sonar-scanner
+  - ./gradlew check
   
 notifications:
-  slack: letech:6iQNboxAjhcmAx2B0CW7LpJq
+  slack: $SLACK

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'checkstyle'
     id 'org.jetbrains.intellij' version '0.4.15'
     id "org.sonarqube" version "2.8"
 }
@@ -24,4 +25,9 @@ patchPluginXml {
     changeNotes """
       Add change notes here.<br>
       <em>most HTML tags may be used</em>"""
+}
+
+checkstyle {
+    configFile = file('/google_checks.xml')
+    maxWarnings = 0
 }


### PR DESCRIPTION
Using checkstyle with Google Java Style (google_checks). One can check their coding style with `./gradlew check`. The same check is done by Travis and build fails if there are style issues.