### PR TITLE
Code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ gradle-app.setting
 .idea/vcs.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
+.idea/codeStyles/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'checkstyle'
+    id 'jacoco'
     id 'org.jetbrains.intellij' version '0.4.15'
     id "org.sonarqube" version "2.8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,3 +32,15 @@ checkstyle {
     configFile = file('/google_checks.xml')
     maxWarnings = 0
 }
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.8
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification


### PR DESCRIPTION
# Description
The `check` task of Gradle (which is also run by Travis) measures code coverage using JaCoCo and requires 80 % of instructions be tested.

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
