### PR TITLE
Initial layout

### DIFF
--- a/src/main/java/fi/aalto/cs/intellij/actions/AboutAction.java
+++ b/src/main/java/fi/aalto/cs/intellij/actions/AboutAction.java
@@ -1,0 +1,13 @@
+package fi.aalto.cs.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import fi.aalto.cs.intellij.ui.AboutDialog;
+import org.jetbrains.annotations.NotNull;
+
+public class AboutAction extends AnAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    AboutDialog.display();
+  }
+}

--- a/src/main/java/fi/aalto/cs/intellij/actions/ToolWindowAction.java
+++ b/src/main/java/fi/aalto/cs/intellij/actions/ToolWindowAction.java
@@ -1,0 +1,21 @@
+package fi.aalto.cs.intellij.actions;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import fi.aalto.cs.intellij.ui.ExerciseList;
+import org.jetbrains.annotations.NotNull;
+
+public class ToolWindowAction implements ToolWindowFactory {
+
+  @Override
+  public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    ExerciseList exerciseList = new ExerciseList();
+    ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+    Content content = contentFactory.createContent(exerciseList.getBasePanel(), "", true);
+    toolWindow.getContentManager().addContent(content);
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/intellij/ui/AboutDialog.java
+++ b/src/main/java/fi/aalto/cs/intellij/ui/AboutDialog.java
@@ -1,0 +1,18 @@
+package fi.aalto.cs.intellij.ui;
+
+import javax.swing.JOptionPane;
+
+public class AboutDialog {
+  private static String description = "This plugin supports the educational use of IntelliJ (and "
+      + "its Scala plugin) in\nprogramming courses that rely on the A+ course platform, which has "
+      + "been\ndeveloped at Aalto University. The plugin accesses programming assignments\nand "
+      + "automated grading services provided by A+ and otherwise enhances\nthe student experience.";
+
+  /**
+   * Displays a small pop up window containing basic information about the plugin.
+   */
+  public static void display() {
+    JOptionPane.showMessageDialog(null, description, "About A+ Plugin",
+        JOptionPane.INFORMATION_MESSAGE);
+  }
+}

--- a/src/main/java/fi/aalto/cs/intellij/ui/ExerciseList.form
+++ b/src/main/java/fi/aalto/cs/intellij/ui/ExerciseList.form
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="fi.aalto.cs.intellij.ui.ExerciseList">
+  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="5f064" class="javax.swing.JList" binding="exercises">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="50"/>
+          </grid>
+        </constraints>
+        <properties>
+          <model>
+            <item value="Week 1"/>
+            <item value="Week 2"/>
+            <item value="Week 3"/>
+            <item value="Week 4"/>
+            <item value="Week 5"/>
+            <item value="Week 6"/>
+            <item value="Week 7"/>
+            <item value="Week 8"/>
+            <item value="Week 9"/>
+            <item value="Week 10"/>
+            <item value="Week 11"/>
+            <item value="Week 12"/>
+          </model>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/fi/aalto/cs/intellij/ui/ExerciseList.java
+++ b/src/main/java/fi/aalto/cs/intellij/ui/ExerciseList.java
@@ -1,0 +1,13 @@
+package fi.aalto.cs.intellij.ui;
+
+import javax.swing.JList;
+import javax.swing.JPanel;
+
+public class ExerciseList {
+  private JList exercises;
+  private JPanel basePanel;
+
+  public JPanel getBasePanel() {
+    return basePanel;
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,9 @@
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
+        <toolWindow id="Exercises"
+                    anchor="right"
+                    factoryClass="fi.aalto.cs.intellij.actions.ToolWindowAction" />
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,12 @@
     </extensions>
 
     <actions>
-        <!-- Add your actions here -->
+        <group id="A+.Menu" text="A+" description="A+ Menu">
+            <add-to-group group-id="MainMenu" anchor="last" />
+            <action id="About A+ Plugin"
+                    class="fi.aalto.cs.intellij.actions.AboutAction"
+                    text="About A+ Plugin"
+                    description="Information about the A+ plugin for IntelliJ" />
+        </group>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
# Description
Adds a "placeholder" layout for the plugin, which consists of an exercise list window on the right, and a A+-menu top toolbar button.  

The layout can be inspected using `gradlew runIde`. No unit tests yet, as we still need to decide how to test the GUI of the plugin.

The sonar scanner fails due to a configuration issue unrelated to this PR.

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually
 

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
