### PR TITLE
Remove 'plugin' from the plugin name

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>fi.aalto.cs.intellij-plugin</id>
-    <name>A+ Plugin for IntelliJ</name>
+    <name>A+ for IntelliJ</name>
     <vendor email="intellij-plugin-letech@aalto.fi" url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University</vendor>
 
     <description><![CDATA[

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>fi.aalto.cs.intellij-plugin</id>
-    <name>A+ for IntelliJ</name>
+    <name>A+ LMS</name>
     <vendor email="intellij-plugin-letech@aalto.fi" url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University</vendor>
 
     <description><![CDATA[

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>fi.aalto.cs.intellij-plugin</id>
-    <name>A+ LMS</name>
+    <name>A+ Courses</name>
     <vendor email="intellij-plugin-letech@aalto.fi" url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University</vendor>
 
     <description><![CDATA[


### PR DESCRIPTION
# Description
Plugin review by JetBrains:
> Hello,
   Please change the name of your plugin. It should not contain such word as 'Plugin'.

> Hello,
    Could you please remove the word 'Plugin' from the name of your plugin.