### PR TITLE
Remove JaCoCo (because code coverage is measured by SonarCloud) [issu…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'checkstyle'
-    id 'jacoco'
     id 'org.jetbrains.intellij' version '0.4.15'
     id "org.sonarqube" version "2.8"
 }
@@ -32,15 +31,3 @@ checkstyle {
     configFile = file('/google_checks.xml')
     maxWarnings = 0
 }
-
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.8
-            }
-        }
-    }
-}
-
-check.dependsOn jacocoTestCoverageVerification


### PR DESCRIPTION
…e #35]

# Description

JaCoCo removed as redundant

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [ ] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
