### PR TITLE
Plugin only to be used with IntelliJ IDEA [#45]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
 intellij {
     version '2019.3.1'
+    plugins = ['java']
 }
 
 publishPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,7 @@
     ]]>
     </change-notes>
 
-    <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Exercises"


### PR DESCRIPTION
# Description
With these changes, plugin should be available only to IntelliJ IDEA, no other JetBrains products.

See doc:
http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html#modules-specific-to-functionality

I have tested that plugin compiles and runs with this setup. Whether what I said above is true or not, can be seen after merge and publish. 

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
