### PR TITLE
required plugin gets enabled on action, but not persisted w restart

### DIFF
--- a/src/main/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationAction.java
+++ b/src/main/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationAction.java
@@ -9,7 +9,6 @@ import com.intellij.notification.NotificationAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.extensions.PluginId;
 import java.util.List;
-import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -18,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 public class EnablePluginsNotificationAction extends NotificationAction {
 
   private List<IdeaPluginDescriptor> disabledPluginDescriptors;
-  private final PluginProvider pluginProvider;
+  private final PluginEnabler pluginEnabler;
 
   /**
    * Builds the action.
@@ -27,7 +26,7 @@ public class EnablePluginsNotificationAction extends NotificationAction {
    *                                  enabled.
    */
   public EnablePluginsNotificationAction(List<IdeaPluginDescriptor> disabledPluginDescriptors) {
-    this(disabledPluginDescriptors, PluginManager::getPlugin);
+    this(disabledPluginDescriptors, PluginManager::enablePlugin);
   }
 
   /**
@@ -35,15 +34,15 @@ public class EnablePluginsNotificationAction extends NotificationAction {
    *
    * @param disabledPluginDescriptors is a {@link List} of {@link IdeaPluginDescriptor} that can be
    *                                  enabled.
-   * @param pluginProvider            is a {@link PluginProvider} exposed for testing purposes.
+   * @param pluginEnabler             is a {@link PluginEnabler} exposed for testing purposes.
    */
   public EnablePluginsNotificationAction(
       @NotNull List<IdeaPluginDescriptor> disabledPluginDescriptors,
-      PluginProvider pluginProvider) {
+      PluginEnabler pluginEnabler) {
     super("Enable the required plugin(s) ("
         + getPluginsNamesString(disabledPluginDescriptors) + ").");
     this.disabledPluginDescriptors = disabledPluginDescriptors;
-    this.pluginProvider = pluginProvider;
+    this.pluginEnabler = pluginEnabler;
   }
 
   /**
@@ -54,26 +53,25 @@ public class EnablePluginsNotificationAction extends NotificationAction {
    */
   @Override
   public void actionPerformed(@NotNull AnActionEvent e, @NotNull Notification notification) {
-    disabledPluginDescriptors.forEach(descriptor -> Objects
-        .requireNonNull(pluginProvider.getPlugin(descriptor.getPluginId())).setEnabled(true));
+    disabledPluginDescriptors
+        .forEach(descriptor -> pluginEnabler.enable(descriptor.getPluginId().getIdString()));
     notification.expire();
   }
 
   /**
-   * An abstract interface for an object that provides {@link IdeaPluginDescriptor} based on
-   * supplied {@link PluginId}s. The most useful realization of this interface is {@code
-   * PluginManager::getPlugin}.
+   * An abstract interface for an object that enables plugins based on supplied {@link String} that
+   * represent {@link PluginId}s. The most useful realization of this interface is {@code
+   * PluginManager::enablePlugin}.
    */
   @FunctionalInterface
-  public interface PluginProvider {
+  public interface PluginEnabler {
 
     /**
-     * Searches for an {@link IdeaPluginDescriptor} with the {@code pluginId}.
+     * Enables a plugin based on the given PluginId represented as {@link String}.
      *
-     * @param pluginId is the id of the desired plugin.
-     * @return an {@link IdeaPluginDescriptor} which corresponds to {@code pluginId} or {@code
-     * null} if the plugin could not be found.
+     * @param pluginId is the {@link String} id of the desired plugin.
+     * @return is true for the case of successful enablement and false if it did not work.
      */
-    IdeaPluginDescriptor getPlugin(PluginId pluginId);
+    boolean enable(String pluginId);
   }
 }

--- a/src/test/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationActionFTest.java
+++ b/src/test/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationActionFTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.notification.Notification;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import fi.aalto.cs.intellij.PluginsTestHelper;
@@ -20,8 +21,9 @@ public class EnablePluginsNotificationActionFTest extends PluginsTestHelper {
     List<IdeaPluginDescriptor> descriptorList = new ArrayList<>();
     IdeaPluginDescriptor ideaPluginDescriptor = getIdeaCorePluginDescriptor();
     descriptorList.add(ideaPluginDescriptor);
-    ideaPluginDescriptor.setEnabled(false);
-    assertFalse(ideaPluginDescriptor.isEnabled());
+    boolean disabled = PluginManager
+        .disablePlugin(ideaPluginDescriptor.getPluginId().getIdString());
+    assertTrue("The core plugin is disabled.", disabled);
 
     //when
     EnablePluginsNotificationAction enableMissingPluginsAction =

--- a/src/test/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationActionTest.java
+++ b/src/test/java/fi/aalto/cs/intellij/actions/EnablePluginsNotificationActionTest.java
@@ -1,58 +1,41 @@
 package fi.aalto.cs.intellij.actions;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.notification.Notification;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.extensions.PluginId;
 import fi.aalto.cs.intellij.PluginsTestHelper;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class EnablePluginsNotificationActionTest extends PluginsTestHelper {
 
   @Test
   public void testActionPerformed() {
-    // given
+    //given
+    AtomicInteger numberOfCallsOfInstall = new AtomicInteger(0);
     List<IdeaPluginDescriptor> descriptorList = getDummyPluginsListOfTwo();
-    Map<PluginId, IdeaPluginDescriptor> descriptors = new HashMap<>();
 
-    descriptorList.forEach(descriptor -> {
-      descriptor.setEnabled(false);
-      descriptors.put(descriptor.getPluginId(), descriptor);
-    });
-
-    assertFalse("The first created dummy plugin is disabled.",
-        descriptorList.get(0).isEnabled());
-    assertFalse("The second created dummy plugin is disabled.",
-        descriptorList.get(1).isEnabled());
+    AnActionEvent anActionEvent = mock(AnActionEvent.class);
+    Notification notification = mock(Notification.class);
 
     //when
-    EnablePluginsNotificationAction enableMissingPluginsAction =
-        new EnablePluginsNotificationAction(new ArrayList<>(descriptors.values()),
-            descriptors::get);
-
-    AnActionEvent anActionEvent = Mockito.mock(AnActionEvent.class);
-    Notification notification = Mockito.mock(Notification.class);
-    enableMissingPluginsAction.actionPerformed(anActionEvent, notification);
+    EnablePluginsNotificationAction enablePluginsNotificationAction =
+        new EnablePluginsNotificationAction(
+            descriptorList,
+            descriptor -> {
+              numberOfCallsOfInstall.getAndIncrement();
+              return true;
+            });
+    enablePluginsNotificationAction.actionPerformed(anActionEvent, notification);
 
     //then
-    assertTrue("The first created dummy plugin is enabled.",
-        descriptorList.get(0).isEnabled());
-    assertTrue("The second created dummy plugin is enabled.",
-        descriptorList.get(1).isEnabled());
-    assertTrue("Action text contains a name of a first dummy plugin.",
-        enableMissingPluginsAction.getTemplateText().contains("Scala"));
-    assertTrue("Action text contains a name of a second dummy plugin.",
-        enableMissingPluginsAction.getTemplateText().contains("A+ Courses"));
-    assertTrue("Action text contains the base part of the notification.",
-        enableMissingPluginsAction.getTemplateText().contains("Enable the required plugin(s)"));
     verify(notification, times(1)).expire();
+    assertEquals("Enable method should be called required amount of times.", 2,
+        numberOfCallsOfInstall.get());
   }
 }

--- a/src/test/java/fi/aalto/cs/intellij/actions/InstallPluginsNotificationActionTest.java
+++ b/src/test/java/fi/aalto/cs/intellij/actions/InstallPluginsNotificationActionTest.java
@@ -33,7 +33,6 @@ public class InstallPluginsNotificationActionTest extends PluginsTestHelper {
     installPluginsNotificationAction.actionPerformed(anActionEvent, notification);
 
     //then
-
     verify(notification, times(1)).expire();
     assertEquals("Installation method should be called required amount of times.", 2,
         numberOfCallsOfInstall.get());


### PR DESCRIPTION
add code to fix the bug and update tests

# Description
seems to be OKsh now

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
