### PR TITLE
Get required plugins from the currently loaded course

### DIFF
--- a/src/main/java/fi/aalto/cs/intellij/activities/RequiredPluginsCheckerActivity.java
+++ b/src/main/java/fi/aalto/cs/intellij/activities/RequiredPluginsCheckerActivity.java
@@ -4,6 +4,7 @@ import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.createListOf
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterDisabledPluginDescriptors;
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterMissingOrDisabledPluginNames;
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterMissingPluginDescriptors;
+import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.getRequiredPlugins;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.notification.Notification;
@@ -14,7 +15,6 @@ import fi.aalto.cs.intellij.actions.EnablePluginsNotificationAction;
 import fi.aalto.cs.intellij.actions.InstallPluginsNotificationAction;
 import fi.aalto.cs.intellij.notifications.EnablePluginsNotification;
 import fi.aalto.cs.intellij.notifications.InstallPluginsNotification;
-import fi.aalto.cs.intellij.services.PluginSettings;
 import java.util.List;
 import java.util.Map;
 
@@ -47,10 +47,7 @@ public class RequiredPluginsCheckerActivity implements StartupActivity {
    */
   @NotNull
   private List<IdeaPluginDescriptor> getActualListOfMissingOrDisabledIdeaPluginDescriptors() {
-    Map<String, String> requiredPlugins = PluginSettings
-        .getInstance()
-        .getCurrentlyLoadedCourse()
-        .getRequiredPlugins();
+    Map<String, String> requiredPlugins = getRequiredPlugins();
     Map<String, String> missingOrDisabledPlugins
         = filterMissingOrDisabledPluginNames(requiredPlugins);
     return createListOfMissingOrDisabledPluginDescriptors(missingOrDisabledPlugins);

--- a/src/main/java/fi/aalto/cs/intellij/activities/RequiredPluginsCheckerActivity.java
+++ b/src/main/java/fi/aalto/cs/intellij/activities/RequiredPluginsCheckerActivity.java
@@ -4,7 +4,6 @@ import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.createListOf
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterDisabledPluginDescriptors;
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterMissingOrDisabledPluginNames;
 import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.filterMissingPluginDescriptors;
-import static fi.aalto.cs.intellij.utils.RequiredPluginsCheckerUtil.getRequiredPluginNamesMap;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.notification.Notification;
@@ -15,8 +14,10 @@ import fi.aalto.cs.intellij.actions.EnablePluginsNotificationAction;
 import fi.aalto.cs.intellij.actions.InstallPluginsNotificationAction;
 import fi.aalto.cs.intellij.notifications.EnablePluginsNotification;
 import fi.aalto.cs.intellij.notifications.InstallPluginsNotification;
+import fi.aalto.cs.intellij.services.PluginSettings;
 import java.util.List;
 import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -46,10 +47,13 @@ public class RequiredPluginsCheckerActivity implements StartupActivity {
    */
   @NotNull
   private List<IdeaPluginDescriptor> getActualListOfMissingOrDisabledIdeaPluginDescriptors() {
-    Map<String, String> requiredPluginNames = getRequiredPluginNamesMap();
-    Map<String, String> missingOrDisabledPluginNames = filterMissingOrDisabledPluginNames(
-        requiredPluginNames);
-    return createListOfMissingOrDisabledPluginDescriptors(missingOrDisabledPluginNames);
+    Map<String, String> requiredPlugins = PluginSettings
+        .getInstance()
+        .getCurrentlyLoadedCourse()
+        .getRequiredPlugins();
+    Map<String, String> missingOrDisabledPlugins
+        = filterMissingOrDisabledPluginNames(requiredPlugins);
+    return createListOfMissingOrDisabledPluginDescriptors(missingOrDisabledPlugins);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtil.java
+++ b/src/main/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtil.java
@@ -11,6 +11,7 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.extensions.PluginId;
 import fi.aalto.cs.intellij.activities.RequiredPluginsCheckerActivity;
 import fi.aalto.cs.intellij.notifications.FailedToLoadPluginsNotification;
+import fi.aalto.cs.intellij.services.PluginSettings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +31,19 @@ public class RequiredPluginsCheckerUtil {
 
   private static final Logger logger = LoggerFactory
       .getLogger(RequiredPluginsCheckerUtil.class);
+
+  /**
+   * Returns a map containing the required plugins.
+   * @return a {@link Map} of {@link String}s for required plugins, with plugin id as key and
+   *         plugin name as value.
+   */
+  @NotNull
+  public static Map<String, String> getRequiredPlugins() {
+    return PluginSettings
+        .getInstance()
+        .getCurrentlyLoadedCourse()
+        .getRequiredPlugins();
+  }
 
   /**
    * Filters out the plugin names that are missing from the current installation.

--- a/src/main/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtil.java
+++ b/src/main/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtil.java
@@ -13,7 +13,6 @@ import fi.aalto.cs.intellij.activities.RequiredPluginsCheckerActivity;
 import fi.aalto.cs.intellij.notifications.FailedToLoadPluginsNotification;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -32,36 +31,21 @@ public class RequiredPluginsCheckerUtil {
       .getLogger(RequiredPluginsCheckerUtil.class);
 
   /**
-   * Fills in the list of required plugin names.
-   *
-   * <p>Later, reading from the from configuration file might occur here.
-   *
-   * @return a {@link Map} of {@link String}s for required plugins, with plugin name as key and
-   *                            plugin id as value.
-   */
-  @NotNull
-  public static Map<String, String> getRequiredPluginNamesMap() {
-    Map<String, String> requiredPluginNames = new HashMap<>();
-    requiredPluginNames.put("Scala", "org.intellij.scala");
-    return requiredPluginNames;
-  }
-
-  /**
    * Filters out the plugin names that are missing from the current installation.
    *
-   * @param requiredPluginNames is a {@link Map} of {@link String}s for required plugins, with
-   *                            plugin name as key and plugin id as value.
+   * @param requiredPlugins is a {@link Map} of {@link String}s for required plugins, with
+   *                        plugin id as key and plugin name as value.
    * @return a {@link Map} of {@link String}s for missing plugins, where key is a plugin's name and
    *                            value is plugin's id.
    */
   @NotNull
-  public static Map<String, String> filterMissingOrDisabledPluginNames(@NotNull
-      Map<String, String> requiredPluginNames) {
-    return requiredPluginNames
+  public static Map<String, String> filterMissingOrDisabledPluginNames(
+      @NotNull Map<String, String> requiredPlugins) {
+    return requiredPlugins
         .entrySet()
         .stream()
         .filter(RequiredPluginsCheckerUtil::isEntryContentsNonNull)
-        .filter(entry -> isPluginMissingOrDisabled(entry.getValue()))
+        .filter(entry -> isPluginMissingOrDisabled(entry.getKey()))
         .collect(toMap(Entry::getKey, Entry::getValue));
   }
 
@@ -93,17 +77,17 @@ public class RequiredPluginsCheckerUtil {
    *
    * <p>Note! This won't work if the required plugins aren't published in JB's main plugin repo.
    *
-   * @param missingOrDisabledPluginNames is a {@link Map} of {@link String}s for missing plugins,
-   *                                     where key is a plugin's name and value is plugin's id.
+   * @param missingOrDisabledPlugins is a {@link Map} of {@link String}s for missing plugins,
+   *                                 where key is a plugin's id and value is plugin's name.
    * @return a {@link List} of {@link IdeaPluginDescriptor} corresponding to the input.
    */
   @NotNull
-  public static List<IdeaPluginDescriptor> createListOfMissingOrDisabledPluginDescriptors(@NotNull
-      Map<String, String> missingOrDisabledPluginNames) {
+  public static List<IdeaPluginDescriptor> createListOfMissingOrDisabledPluginDescriptors(
+      @NotNull Map<String, String> missingOrDisabledPlugins) {
     List<IdeaPluginDescriptor> missingOrDisabledIdeaPluginDescriptors = new ArrayList<>();
-    if (!missingOrDisabledPluginNames.isEmpty()) {
+    if (!missingOrDisabledPlugins.isEmpty()) {
       List<IdeaPluginDescriptor> availableIdeaPluginDescriptors = getAvailablePluginsFromMainRepo();
-      missingOrDisabledPluginNames.forEach((name, id) ->
+      missingOrDisabledPlugins.forEach((id, name) ->
           availableIdeaPluginDescriptors
           .stream()
           .filter(Objects::nonNull)

--- a/src/test/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtilFTest.java
+++ b/src/test/java/fi/aalto/cs/intellij/utils/RequiredPluginsCheckerUtilFTest.java
@@ -18,8 +18,7 @@ public class RequiredPluginsCheckerUtilFTest extends PluginsTestHelper {
   public void testFilterMissingOrDisabledPluginNamesWithCorrectInputWorks() {
     Map<String, String> requiredPluginNames = new HashMap<>();
     getDummyPluginsListOfTwo().forEach(descriptor ->
-        requiredPluginNames.put(descriptor.getName(),
-        descriptor.getPluginId().getIdString()));
+        requiredPluginNames.put(descriptor.getPluginId().getIdString(), descriptor.getName()));
 
     Map<String, String> result =
         RequiredPluginsCheckerUtil.filterMissingOrDisabledPluginNames(requiredPluginNames);
@@ -31,8 +30,7 @@ public class RequiredPluginsCheckerUtilFTest extends PluginsTestHelper {
   public void testFilterMissingOrDisabledPluginNamesWorksWithCorrectInputWithNullWorks() {
     Map<String, String> requiredPluginNames = new HashMap<>();
     getDummyPluginsListOfTwo().forEach(descriptor ->
-        requiredPluginNames.put(descriptor.getName(),
-        descriptor.getPluginId().getIdString()));
+        requiredPluginNames.put(descriptor.getPluginId().getIdString(), descriptor.getName()));
     requiredPluginNames.put(null, null);
 
     Map<String, String> result =


### PR DESCRIPTION
# Description
Modifies the check for required plugins so that the required plugins are checked from the currently loaded course instead of a hard coded list of required plugins. Some code and tests had to be modified as the maps now have plugin IDs as keys and plugin names as values.

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
