### PR TITLE
Plugin-ID back to be fi.aalto.cs.intellij-plugin

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
-    <id>fi.aalto.cs.apluscourses</id>
+    <id>fi.aalto.cs.intellij-plugin</id>
     <name>A+ Courses</name>
     <vendor email="intellij-plugin-letech@aalto.fi" url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University</vendor>
 

--- a/src/test/resources/plugins/dummy_a+_plugin.xml
+++ b/src/test/resources/plugins/dummy_a+_plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <version>0.1.101</version>
   <idea-version since-build="193.5662" until-build="193.*"/>
-  <id>fi.aalto.cs.apluscourses</id>
+  <id>fi.aalto.cs.intellij-plugin</id>
   <name>A+ Courses</name>
   <vendor email="intellij-plugin-letech@aalto.fi" url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University</vendor>
   <description>


### PR DESCRIPTION
# Description
Fixes the failing deployment caused by PR #57 by changing the plugin ID to what it was earlier.

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [ ] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
