### PR TITLE
Fixed bug in ModuleInstallerTest.java

### DIFF
--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModuleInstallerTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModuleInstallerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,8 +44,8 @@ public class ModuleInstallerTest {
     installer.install(module);
 
     InOrder order = inOrder(module);
-    order.verify(module, times(1)).fetch();
-    order.verify(module, times(1)).load();
+    order.verify(module).fetch();
+    order.verify(module).load();
 
     assertEquals("Module should be in INSTALLED state, after the installation has ended.",
         Module.INSTALLED, module.stateMonitor.get());
@@ -81,25 +80,25 @@ public class ModuleInstallerTest {
     installer.install(module1);
 
     InOrder order1 = inOrder(module1);
-    order1.verify(module1, times(1)).fetch();
-    order1.verify(module1, times(1)).load();
+    order1.verify(module1).fetch();
+    order1.verify(module1).load();
 
     InOrder order2 = inOrder(firstDep);
-    order2.verify(firstDep, times(1)).fetch();
-    order2.verify(firstDep, times(1)).load();
+    order2.verify(firstDep).fetch();
+    order2.verify(firstDep).load();
 
     InOrder order3 = inOrder(secondDep);
-    order3.verify(secondDep, times(1)).fetch();
-    order3.verify(secondDep, times(1)).load();
+    order3.verify(secondDep).fetch();
+    order3.verify(secondDep).load();
 
     assertEquals("Dependent module should be in INSTALLED state, after the installation has ended.",
         Module.INSTALLED, module1.stateMonitor.get());
 
-    assertEquals("1st dependency should be in INSTALLED state, after the installation has ended.",
-        Module.INSTALLED, firstDep.stateMonitor.get());
+    assertThat("1st dependency should be in LOADED state or further.",
+        firstDep.stateMonitor.get(), greaterThanOrEqualTo(Module.LOADED));
 
-    assertEquals("2nd dependency should be in INSTALLED state, after the installation has ended.",
-        Module.INSTALLED, secondDep.stateMonitor.get());
+    assertThat("2nd dependency should be in LOADED state or further.",
+        secondDep.stateMonitor.get(), greaterThanOrEqualTo(Module.LOADED));
   }
 
   @Test
@@ -121,11 +120,11 @@ public class ModuleInstallerTest {
     installer.install(modules);
 
     InOrder order1 = inOrder(module1);
-    order1.verify(module1, times(1)).fetch();
-    order1.verify(module1, times(1)).load();
+    order1.verify(module1).fetch();
+    order1.verify(module1).load();
     InOrder order2 = inOrder(module2);
-    order2.verify(module2, times(1)).fetch();
-    order2.verify(module2, times(1)).load();
+    order2.verify(module2).fetch();
+    order2.verify(module2).load();
 
     assertEquals("Module 1 should be in INSTALLED state, after the installation has ended.",
         Module.INSTALLED, module1.stateMonitor.get());


### PR DESCRIPTION
# Description
Fixes bug that caused fail of [build 393](https://travis-ci.com/Aalto-LeTech/intellij-plugin/builds/150433678). Basically, a unit test, namely `testInstallDependencies` had too strong assertions which were not guaranteed to be fulfilled. I fixed the assertions to match the spec of the `ModuleInstaller.install()`. Also removed some redundant `times(1)` arguments from that file.

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [ ] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
