### PR TITLE
Import Ide Settings

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -181,8 +181,8 @@ a manual testing manual. Marked with a github issue label "manual testing". Issu
       </li>
     </ol>
   </div>
-  </details>
-  <details>
+ </details>
+ <details>
     <summary>
       <a href="https://github.com/Aalto-LeTech/intellij-plugin/issues/66">implement REPL thingy #66</a>
     </summary>
@@ -221,4 +221,30 @@ a manual testing manual. Marked with a github issue label "manual testing". Issu
           </li>
         </ol>
       </div>
+</details>
+<details>
+  <summary>
+    <a href="https://github.com/Aalto-LeTech/intellij-plugin/issues/117">Import IDE settings from remote</a>
+  </summary>
+  <div>
+    <h5>Part 1. Testing the error message</h5>
+    <ol>
+      <li>Start the IDE and make sure the course has been loaded (check the modules list for an example).</li>
+      <li>Disable networking from the computer.</li>
+      <li>Attempt to import course IDE settings from the A+ menu in the top toolbar.</li>
+      <li>Observe an error message dialog that notifies the user that an error occurred.</li>
+    </ol>
+  </div>
+  <div>
+    <h5>Part 2. Importing IDE settings</h5>
+    <ol>
+      <li>Import course IDE settings from the A+ menu in the top toolbar.</li>
+      <li>Observe a confirmation message dialog, which warns the user that settings are overwritten.</li>
+      <li>After the IDE settings have been imported, observe a message dialog proposing a restart.</li>
+      <li>
+      After restarting the IDE, ensure that the settings have been successfully imported.
+      For an example, the IDE should now be in dark mode.
+      </li>
+    </ol>
+  </div>
 </details>

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ImportIdeSettingsAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ImportIdeSettingsAction.java
@@ -1,0 +1,94 @@
+package fi.aalto.cs.apluscourses.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ex.ApplicationEx;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import fi.aalto.cs.apluscourses.intellij.model.IdeSettingsImporter;
+import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
+import fi.aalto.cs.apluscourses.model.Course;
+import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
+import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
+import java.io.IOException;
+import java.net.URL;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ImportIdeSettingsAction extends AnAction implements DumbAware {
+  @NotNull
+  private MainViewModelProvider mainViewModelProvider;
+
+  public ImportIdeSettingsAction(@NotNull MainViewModelProvider mainViewModelProvider) {
+    this.mainViewModelProvider = mainViewModelProvider;
+  }
+
+  public ImportIdeSettingsAction() {
+    this(PluginSettings.getInstance());
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    CourseViewModel courseViewModel = mainViewModelProvider
+        .getMainViewModel(e.getProject())
+        .courseViewModel
+        .get();
+    if (courseViewModel == null) {
+      return;
+    }
+    Course course = courseViewModel.getModel();
+
+    URL ideSettingsUrl = course.getResourceUrls().get("ideSettings");
+    if (ideSettingsUrl == null) {
+      informNoSettings(e.getProject(), course);
+      return;
+    }
+    if (userCancelsImport(e.getProject())) {
+      return;
+    }
+    try {
+      IdeSettingsImporter.importFromUrl(ideSettingsUrl);
+      if (userWantsToRestart(e.getProject())) {
+        restart();
+      }
+    } catch (IOException | UnexpectedResponseException ex) {
+      informErrorOccurred(e.getProject());
+    }
+  }
+
+  private static boolean userCancelsImport(@Nullable Project project) {
+    int answer = Messages.showOkCancelDialog(project, "Importing IDE settings replaces the "
+        + " current settings. Existing custom settings are overwritten.", "Import IDE Settings",
+        "Import IDE Settings", "Cancel", Messages.getQuestionIcon());
+    return answer != Messages.OK;
+  }
+
+  private static boolean userWantsToRestart(@Nullable Project project) {
+    int answer = Messages.showYesNoDialog(project,
+        "IDE settings imported succesfully. Restart the IDE now to reload the settings?",
+        "Restart Needed", Messages.getQuestionIcon());
+    return answer == Messages.YES;
+  }
+
+  private static void informNoSettings(@Nullable Project project, @NotNull Course course) {
+    Messages.showInfoMessage(
+        project,
+        "The course \"" + course.getName() + "\" does not provide custom IDE settings",
+        "No IDE Settings Found");
+  }
+
+  private static void informErrorOccurred(@Nullable Project project) {
+    Messages.showErrorDialog(project,"An error occurred while importing IDE settings. Please "
+        + "check your network connection and try again, or contact the course staff if the issue "
+        + "persists.", "Import IDE Settings");
+  }
+
+  private static void restart() {
+    ApplicationManager.getApplication().invokeLater(
+        () -> ((ApplicationEx) ApplicationManager.getApplication()).restart(true));
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IdeSettingsImporter.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IdeSettingsImporter.java
@@ -1,0 +1,59 @@
+package fi.aalto.cs.apluscourses.intellij.model;
+
+import com.intellij.ide.startup.StartupActionScriptManager;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.updateSettings.impl.UpdateSettings;
+import com.intellij.openapi.util.io.FileUtilRt;
+import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
+import fi.aalto.cs.apluscourses.utils.CoursesClient;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
+
+public class IdeSettingsImporter {
+
+  private IdeSettingsImporter() {
+
+  }
+
+  /**
+   * Creates a temporary file and downloads the settings ZIP file from the given URL to the
+   * temporary file. The IDE settings are then imported from the temporary file using {@link
+   * IdeSettingsImporter#importFromFile}.
+   * @param settingsUrl The URL from which the IDE settings ZIP file is downloaded.
+   * @throws IOException                 If an IO error occurs.
+   * @throws UnexpectedResponseException If the request made to the URL results in an unexpected
+   *                                     response. This usually indicates an error in the course
+   *                                     configuration.
+   */
+  public static void importFromUrl(@NotNull URL settingsUrl)
+      throws IOException, UnexpectedResponseException {
+    File tempFile = FileUtilRt.createTempFile("course-ide-settings", ".zip");
+    CoursesClient.fetchZip(settingsUrl, tempFile);
+    importFromFile(tempFile);
+  }
+
+  /**
+   * Adds startup actions, which unzip the given ZIP file in the IntelliJ IDEA configuration
+   * directory and delete the given ZIP file. The IDE is also configured to check for configuration
+   * updates on restart. The IDE must be restarted for the given IDE settings to take effect. It's
+   * important to ensure that the file exists when the IDE is restarted, since that's when the file
+   * gets unzipped.
+   * @param file A ZIP file containing the IDE settings. Such a file can be created using IDEA's
+   *             "Export Settings" feature.
+   * @throws IOException If an IO error occurs.
+   */
+  public static void importFromFile(@NotNull File file) throws IOException {
+    String configPath = FileUtilRt.toSystemIndependentName(PathManager.getConfigPath());
+    StartupActionScriptManager.addActionCommands(
+        Arrays.asList(
+            new StartupActionScriptManager.UnzipCommand(file, new File(configPath)),
+            new StartupActionScriptManager.DeleteCommand(file)
+        )
+    );
+    UpdateSettings.getInstance().forceCheckForUpdateAfterRestart();
+  }
+}
+

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.intellij.model;
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Module;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -14,9 +15,9 @@ class IntelliJCourse extends Course {
   IntelliJCourse(@NotNull String name,
                  @NotNull List<Module> modules,
                  @NotNull Map<String, String> requiredPlugins,
+                 @NotNull Map<String, URL> resourceUrls,
                  @NotNull Project project) {
-    super(name, modules, requiredPlugins);
-
+    super(name, modules, requiredPlugins, resourceUrls);
     this.project = project;
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -27,8 +27,10 @@ public class IntelliJModelFactory implements ModelFactory {
   @Override
   public Course createCourse(@NotNull String name,
                              @NotNull List<Module> modules,
-                             @NotNull Map<String, String> requiredPlugins) {
-    IntelliJCourse course = new IntelliJCourse(name, modules, requiredPlugins, project);
+                             @NotNull Map<String, String> requiredPlugins,
+                             @NotNull Map<String, URL> resourceUrls) {
+    IntelliJCourse course
+        = new IntelliJCourse(name, modules, requiredPlugins, resourceUrls, project);
     // Add a module change listener with the created course instance to the project
     project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener() {
       @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -8,7 +8,8 @@ import org.jetbrains.annotations.NotNull;
 public interface ModelFactory {
   Course createCourse(@NotNull String name,
                       @NotNull List<Module> modules,
-                      @NotNull Map<String, String> requiredPlugins);
+                      @NotNull Map<String, String> requiredPlugins,
+                      @NotNull Map<String, URL> resourceUrls);
 
   Module createModule(@NotNull String name, @NotNull URL url);
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,10 @@
     <actions>
         <group id="A+.Menu" text="A+" description="A+ Menu">
             <add-to-group group-id="MainMenu" anchor="last" />
+            <action id="Import Course IDE Settings"
+                    class="fi.aalto.cs.apluscourses.intellij.actions.ImportIdeSettingsAction"
+                    text="Import Course IDE Settings"
+                    description="Imports the IDE settings for the currently loaded course." />
             <action id="About A+ Plugin"
                     class="fi.aalto.cs.apluscourses.intellij.actions.AboutAction"
                     text="About A+ Plugin"

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/ImportModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/ImportModuleActionTest.java
@@ -47,7 +47,8 @@ public class ImportModuleActionTest {
     modules.add(new ModelExtensions.TestModule("module2"));
     modules.add(new ModelExtensions.TestModule("module3"));
 
-    Course course = new Course("course", modules, Collections.emptyMap());
+    Course course
+        = new Course("course", modules, Collections.emptyMap(), Collections.emptyMap());
     mainViewModel.courseViewModel.set(new CourseViewModel(course));
 
     moduleInstaller = mock(ModuleInstaller.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -20,13 +20,16 @@ public class CourseTest {
   private static final ModelFactory MODEL_FACTORY = new ModelExtensions.TestModelFactory() {};
 
   @Test
-  public void testCreateCourse() {
+  public void testCreateCourse() throws MalformedURLException {
     Module module1 = new ModelExtensions.TestModule("Module1");
     Module module2 = new ModelExtensions.TestModule("Module2");
     List<Module> modules = Arrays.asList(module1, module2);
     Map<String, String> requiredPlugins = new HashMap<>();
     requiredPlugins.put("org.intellij.awesome_plugin", "Awesome Plugin");
-    Course course = new Course("Tester Course", modules, requiredPlugins);
+    Map<String, URL> resourceUrls = new HashMap<>();
+    resourceUrls.put("key", new URL("http://localhost:8000"));
+    Course course
+        = new Course("Tester Course", modules, requiredPlugins, resourceUrls);
     assertEquals("The name of the course should be the same as that given to the constructor",
         "Tester Course", course.getName());
     assertEquals("The modules of the course should be the same as those given to the constructor",
@@ -36,13 +39,17 @@ public class CourseTest {
     assertEquals("The required plugins of the course should be the same as those given to the "
             + "constructor", "Awesome Plugin",
         course.getRequiredPlugins().get("org.intellij.awesome_plugin"));
+    assertEquals(
+        "The resource URLs of the course should the same as those given to the constructor",
+        new URL("http://localhost:8000"), course.getResourceUrls().get("key"));
   }
 
   @Test
   public void testGetModule() throws MalformedURLException, NoSuchModuleException {
     Module module1 = new ModelExtensions.TestModule("Test Module", new URL("https://example.com"));
     Module module2 = new ModelExtensions.TestModule("Awesome Module", new URL("https://slack.com"));
-    Course course = new Course("", Arrays.asList(module1, module2), new HashMap<>());
+    Course course = new Course("", Arrays.asList(module1, module2), Collections.emptyMap(),
+        Collections.emptyMap());
     assertEquals("Course#getModule should return the correct module",
         "Awesome Module", course.getModule("Awesome Module").getName());
     assertEquals("Course#getModule should return the correct module",
@@ -51,7 +58,8 @@ public class CourseTest {
 
   @Test(expected = NoSuchModuleException.class)
   public void testGetModuleWithMissingModule() throws NoSuchModuleException {
-    Course course = new Course("Just some course", Collections.emptyList(), Collections.emptyMap());
+    Course course = new Course("Just some course", Collections.emptyList(),
+        Collections.emptyMap(), Collections.emptyMap());
     course.getModule("Test Module");
   }
 
@@ -59,7 +67,8 @@ public class CourseTest {
   public void testGetModuleOpt() throws MalformedURLException {
     Module module1 = new ModelExtensions.TestModule("Test test", new URL("https://duckduckgo.com"));
     Module module2 = new ModelExtensions.TestModule("Awesome Module", new URL("https://gmail.com"));
-    Course course = new Course("", Arrays.asList(module1, module2), new HashMap<>());
+    Course course = new Course("", Arrays.asList(module1, module2), Collections.emptyMap(),
+        Collections.emptyMap());
     Module optModule = course.getModuleOpt("Awesome Module");
     assertNotNull("Course#getModuleOpt should not return null for an existing module", optModule);
     assertEquals("Course#getModuleOpt should return the correct module",
@@ -70,7 +79,8 @@ public class CourseTest {
 
   @Test
   public void testGetModuleOptWithMissingModule() {
-    Course course = new Course("Meaningless Name", Collections.emptyList(), Collections.emptyMap());
+    Course course = new Course("Meaningless Name", Collections.emptyList(),
+        Collections.emptyMap(), Collections.emptyMap());
     assertNull("Course#getModuleOpt should return null for a missing module",
         course.getModuleOpt("No module has this name"));
   }
@@ -80,11 +90,13 @@ public class CourseTest {
       + "\"Scala\",\"org.test.tester\":\"Tester\"}";
   private static String modulesJson = "\"modules\":[{\"name\":\"O1Library\",\"url\":"
       + "\"https://wikipedia.org\"},{\"name\":\"GoodStuff\",\"url\":\"https://example.com\"}]";
+  private static String resourcesJson = "\"resources\":{\"abc\":\"http://example.com\","
+      + "\"def\":\"http://example.org\"}";
 
   @Test
   public void testFromConfigurationFile() throws MalformedCourseConfigurationFileException {
-    StringReader stringReader
-        = new StringReader("{" + nameJson + "," + requiredPluginsJson + "," + modulesJson + "}");
+    StringReader stringReader = new StringReader("{" + nameJson + "," + requiredPluginsJson + ","
+        + modulesJson + "," + resourcesJson + "}");
     Course course = Course.fromConfigurationData(stringReader, "./path/to/file", MODEL_FACTORY);
     assertEquals("Course should have the same name as that in the configuration JSON",
         "Awesome Course", course.getName());
@@ -96,6 +108,10 @@ public class CourseTest {
         "O1Library", course.getModules().get(0).getName());
     assertEquals("The course should have the modules of the configuration JSON",
         "GoodStuff", course.getModules().get(1).getName());
+    assertEquals("The course should have the resource URLs of the configuration JSON",
+        "http://example.com", course.getResourceUrls().get("abc").toString());
+    assertEquals("The course should have the resource URLs of the configuration JSON",
+        "http://example.org", course.getResourceUrls().get("def").toString());
   }
 
   @Test(expected = MalformedCourseConfigurationFileException.class)

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -71,8 +71,9 @@ public class ModelExtensions {
     @Override
     public Course createCourse(@NotNull String name,
                                @NotNull List<Module> modules,
-                               @NotNull Map<String, String> requiredPlugins) {
-      return new Course(name, modules, requiredPlugins);
+                               @NotNull Map<String, String> requiredPlugins,
+                               @NotNull Map<String, URL> resourceUrls) {
+      return new Course(name, modules, requiredPlugins, resourceUrls);
     }
 
     @Override


### PR DESCRIPTION
# Description

Adds an action for importing global IDE settings. The IDE settings ZIP file is fetched from a URL specified in the course configuration file.

### TODO
 - [ ] More unit tesets
 
# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [x] Yes
- [ ] Not yet. I will do it next.
- [ ] Not relevant
