### PR TITLE
setting for starting a REPL configuration window is persistent over r…

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class InitializationActivity implements StartupActivity, DumbAware {
+
   private static final Logger logger = LoggerFactory.getLogger(InitializationActivity.class);
 
   @NotNull
@@ -63,5 +64,6 @@ public class InitializationActivity implements StartupActivity, DumbAware {
         .getMainViewModel(project).courseViewModel.set(new CourseViewModel(course));
     ActionUtil.launch(RequiredPluginsCheckerAction.ACTION_ID,
         new ExtendedDataContext().withProject(project));
+    PluginSettings.initiateLocalSettingShowReplConfigurationDialog();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -1,5 +1,8 @@
 package fi.aalto.cs.apluscourses.intellij.services;
 
+import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalSettingsNames.A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG;
+
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -12,8 +15,14 @@ import org.jetbrains.annotations.Nullable;
 
 public class PluginSettings implements MainViewModelProvider {
 
+  public interface LocalSettingsNames {
+
+    String A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG = "A+.showReplConfigDialog";
+  }
+
   public static final String COURSE_CONFIGURATION_FILE_URL
       = "https://grader.cs.hut.fi/static/O1_2020/projects/o1_course_config.json";
+  private static final PropertiesComponent propertiesManager = PropertiesComponent.getInstance();
 
   @NotNull
   private final ConcurrentMap<Project, MainViewModel> mainViewModels = new ConcurrentHashMap<>();
@@ -33,6 +42,7 @@ public class PluginSettings implements MainViewModelProvider {
 
   /**
    * Returns a MainViewModel for a specific project.
+   *
    * @param project A project, or null (equivalent for default project).
    * @return A main view model.
    */
@@ -46,8 +56,27 @@ public class PluginSettings implements MainViewModelProvider {
     return mainViewModels.computeIfAbsent(project, this::createNewMainViewModel);
   }
 
+  @NotNull
   private MainViewModel createNewMainViewModel(@NotNull Project project) {
     ProjectManager.getInstance().addProjectManagerListener(project, projectManagerListener);
     return new MainViewModel();
+  }
+
+  public static boolean isShowReplConfigurationDialog() {
+    return propertiesManager.getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
+  }
+
+  //  todo consider to create a listener
+  public static void setShowReplConfigurationDialog(boolean showReplConfigDialog) {
+    propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, showReplConfigDialog);
+  }
+
+  /**
+   * Method that checks if the value is set (exists/non-empty etc.) and sets it to 'true'.
+   */
+  public static void initiateLocalSettingShowReplConfigurationDialog() {
+    if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG)) {
+      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, true);
+    }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ReplConfigurationFormModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ReplConfigurationFormModel.java
@@ -17,9 +17,6 @@ public class ReplConfigurationFormModel {
   private List<String> moduleNames;
   private boolean startRepl = true;
 
-  //todo this goes into course settings once they exist
-  public static boolean showREPLConfigWindow = true;
-
   /**
    * Creates a model for {@link ReplConfigurationForm}.
    *

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
@@ -1,6 +1,5 @@
 package fi.aalto.cs.apluscourses.ui.repl;
 
-import static fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel.showREPLConfigWindow;
 import static java.util.Objects.requireNonNull;
 
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
@@ -8,6 +7,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.vfs.VirtualFile;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -43,7 +43,7 @@ public class ReplConfigurationForm extends JPanel {
    */
   public ReplConfigurationForm(@NotNull ReplConfigurationFormModel model) {
     this.model = model;
-    dontShowThisWindowCheckBox.setSelected(showREPLConfigWindow);
+    dontShowThisWindowCheckBox.setSelected(PluginSettings.isShowReplConfigurationDialog());
 
     infoTextLabel.setText(INFOLABEL_TEXT);
 
@@ -79,7 +79,8 @@ public class ReplConfigurationForm extends JPanel {
   public void updateModel() {
     model.setTargetModuleName(requireNonNull(moduleComboBox.getSelectedItem()).toString());
     model.setModuleWorkingDirectory(workingDirectoryField.getText());
-    showREPLConfigWindow = !dontShowThisWindowCheckBox.isSelected();
+    boolean chosenState = !dontShowThisWindowCheckBox.isSelected();
+    PluginSettings.setShowReplConfigurationDialog(chosenState);
   }
 
   public void cancelReplStart() {

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.{AnActionEvent, CommonDataKeys}
 import com.intellij.openapi.module.{Module, ModuleManager, ModuleUtilCore}
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings
 import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel
 import fi.aalto.cs.apluscourses.ui.repl.{ReplConfigurationDialog, ReplConfigurationForm}
 import org.jetbrains.annotations.{NotNull, Nullable}
@@ -49,7 +50,7 @@ class ReplAction extends RunConsoleAction {
   def setConfigurationConditionally(@NotNull project: Project,
                                     @NotNull module: Module,
                                     @NotNull configuration: ScalaConsoleRunConfiguration): Boolean = {
-    if (ReplConfigurationFormModel.showREPLConfigWindow) {
+    if (PluginSettings.isShowReplConfigurationDialog) {
       val configModel = new ReplConfigurationFormModel(project, getModuleWorkDir(module), module.getName)
 
       createAndShowReplConfigurationDialog(configModel)

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
@@ -1,0 +1,27 @@
+package fi.aalto.cs.apluscourses.intellij.services;
+
+import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalSettingsNames.A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG;
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.junit.Test;
+
+public class PluginSettingsTest extends BasePlatformTestCase {
+
+  @Test
+  public void testInitiateLocalSettingShowReplConfigurationDialogWorks() {
+    //  given
+    PropertiesComponent.getInstance()
+        .unsetValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
+
+    assertFalse("The state of the given setting is now 'unset'.",
+        PropertiesComponent.getInstance().isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
+
+    //  when
+    PluginSettings.initiateLocalSettingShowReplConfigurationDialog();
+
+    //  then
+    assertTrue("The state of the given setting is now set (to 'true').",
+        PropertiesComponent.getInstance().getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
+  }
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.ui.repl;
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import fi.aalto.cs.apluscourses.TestHelper;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -26,7 +27,7 @@ public class ReplConfigurationFormTest extends BasePlatformTestCase implements T
     assertEquals("Form contains the rights informative message",
         ReplConfigurationForm.INFOLABEL_TEXT, form.getInfoTextLabel().getText());
     assertEquals("Form correctly picks up negated flag for showing the config dialog",
-        ReplConfigurationFormModel.showREPLConfigWindow,
+        PluginSettings.isShowReplConfigurationDialog(),
         form.getDontShowThisWindowCheckBox().isSelected());
   }
 

--- a/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
+++ b/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
@@ -4,7 +4,7 @@ package fi.aalto.cs.apluscourses.intellij.actions
 import com.intellij.mock.MockVirtualFile.{dir, file}
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import fi.aalto.cs.apluscourses.intellij.TestHelperScala
-import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.Mockito.{spy, times, verify}
@@ -13,6 +13,7 @@ class ReplActionTest extends BasePlatformTestCase with TestHelperScala {
 
   @Test
   def testSetConfigurationConditionallyWithDoNotShowReplFlagWorks(): Unit = {
+    //  given
     val project = getProject
     val module = getModule
     val configuration = getConfiguration
@@ -21,8 +22,9 @@ class ReplActionTest extends BasePlatformTestCase with TestHelperScala {
     val moduleWorkDir = action.getModuleWorkDir(module)
 
     //  only FALSE branch, as TRUE triggers UI
-    ReplConfigurationFormModel.showREPLConfigWindow = false
+    PluginSettings.setShowReplConfigurationDialog(false);
 
+    //  when
     action.setConfigurationConditionally(project, module, configuration)
 
     //  then


### PR DESCRIPTION
# Description

so I suggest to introduce an additional concept:
* IDE settings (remote, persistent)
* Project settings (remote, persistent)
* **NEW** Local settings (local, persistent) **NEW** - some settings that don't really need to be fetched from A+

otherwise, please review and comment. I'm not sure about not having a local representation of the `A+.showReplConfigDialog`, thus it kinda replaces the listener in this case (but I'm still thinking if the listener is required here).

# Testing

- [x] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant