### PR TITLE
Windows repl naming bug

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -27,9 +27,7 @@ class ReplAction extends RunConsoleAction {
   def checkFileOrFolderIsNull(@Nullable fileOrFolder: VirtualFile): Boolean = fileOrFolder == null
 
   def getModuleWorkDir(@NotNull module: Module): String = {
-    //  for project "root" this points to .../.../.idea folder
-    toSystemIndependentName(ModuleUtilCore.getModuleDirPath(module)
-      .replace("/.idea", ""))
+    toSystemIndependentName(ModuleUtilCore.getModuleDirPath(module))
   }
 
   def setCustomConfigurationFields(@NotNull configuration: ScalaConsoleRunConfiguration,

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -4,6 +4,7 @@ import com.intellij.execution.RunManagerEx
 import com.intellij.openapi.actionSystem.{AnActionEvent, CommonDataKeys}
 import com.intellij.openapi.module.{Module, ModuleManager, ModuleUtilCore}
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtilRt.toSystemIndependentName
 import com.intellij.openapi.vfs.VirtualFile
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings
 import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel
@@ -27,7 +28,8 @@ class ReplAction extends RunConsoleAction {
 
   def getModuleWorkDir(@NotNull module: Module): String = {
     //  for project "root" this points to .../.../.idea folder
-    ModuleUtilCore.getModuleDirPath(module).replace("/.idea", "")
+    toSystemIndependentName(ModuleUtilCore.getModuleDirPath(module)
+      .replace("/.idea", ""))
   }
 
   def setCustomConfigurationFields(@NotNull configuration: ScalaConsoleRunConfiguration,
@@ -44,8 +46,8 @@ class ReplAction extends RunConsoleAction {
   }
 
   /**
-   * Sets configuration fields for the given configuration and returns true. Returns false if the REPL start is
-   * cancelled (i.e. user selects "Cancel" in the REPL configuration dialog).
+   * Sets configuration fields for the given configuration and returns true. Returns false if
+   * the REPL start is cancelled (i.e. user selects "Cancel" in the REPL configuration dialog).
    */
   def setConfigurationConditionally(@NotNull project: Project,
                                     @NotNull module: Module,
@@ -60,7 +62,7 @@ class ReplAction extends RunConsoleAction {
       } else {
         val changedModuleName = configModel.getTargetModuleName
         val changedModule = ModuleManager.getInstance(project).findModuleByName(changedModuleName)
-        val changedWorkDir = configModel.getModuleWorkingDirectory
+        val changedWorkDir = toSystemIndependentName(configModel.getModuleWorkingDirectory)
         setCustomConfigurationFields(configuration, changedWorkDir, changedModuleName, changedModule)
         true
       }
@@ -93,7 +95,7 @@ class ReplAction extends RunConsoleAction {
 
     if (project == null || checkFileOrFolderIsNull(targetFileOrFolder)) return // scalastyle:ignore
 
-    //  get target module & workDir
+    //  get target module
     val module = ModuleUtilCore.findModuleForFile(targetFileOrFolder, project)
 
     val runManagerEx = RunManagerEx.getInstanceEx(project)

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ModuleComboBoxListRendererTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ModuleComboBoxListRendererTest.java
@@ -14,7 +14,7 @@ public class ModuleComboBoxListRendererTest {
     ModuleComboBoxListRenderer renderer = new ModuleComboBoxListRenderer();
 
     //  when
-    renderer.customize(new JList(), "", 0, true, true);
+    renderer.customize(new JList<String>(), "", 0, true, true);
 
     //  then
     assertNotNull("The icon for rendering Modules in ComboBoxList is set",
@@ -29,7 +29,7 @@ public class ModuleComboBoxListRendererTest {
     ModuleComboBoxListRenderer.iconPath = "/fakePath";
 
     //  when
-    renderer.customize(new JList(), "", 0, true, true);
+    renderer.customize(new JList<String>(), "", 0, true, true);
 
     //  then
     assertNull("The icon for rendering Modules in ComboBoxList is NOT set",


### PR DESCRIPTION
# Description

it was a paths related problem, worked on Windows

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually
