### PR TITLE
setting for starting a REPL configuration window is persistent over restart #121

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -64,6 +64,6 @@ public class InitializationActivity implements StartupActivity, DumbAware {
         .getMainViewModel(project).courseViewModel.set(new CourseViewModel(course));
     ActionUtil.launch(RequiredPluginsCheckerAction.ACTION_ID,
         new ExtendedDataContext().withProject(project));
-    PluginSettings.initiateLocalSettingShowReplConfigurationDialog();
+    PluginSettings.getInstance().initiateLocalSettingShowReplConfigurationDialog();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -62,26 +62,28 @@ public class PluginSettings implements MainViewModelProvider {
     return new MainViewModel();
   }
 
-  public static String shouldShowReplConfigurationDialog() {
-    return propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
+  public boolean shouldShowReplConfigurationDialog() {
+    return Boolean.parseBoolean(propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
   }
 
   /**
    * Method to set property, responsible for showing REPL configuration window.
    *
-   * @param showReplConfigDialog a {@link String} representing a boolean value of the flag.
+   * @param showReplConfigDialog a boolean value of the flag.
    */
-  public static void setShowReplConfigurationDialog(String showReplConfigDialog) {
-    propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, showReplConfigDialog);
+  public void setShowReplConfigurationDialog(boolean showReplConfigDialog) {
+    propertiesManager
+        //  a String explicitly
+        .setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, String.valueOf(showReplConfigDialog));
   }
 
   /**
    * Method that checks if the value is set (exists/non-empty etc.) and sets the {@link String}
    * value to 'true'.
    */
-  public static void initiateLocalSettingShowReplConfigurationDialog() {
+  public void initiateLocalSettingShowReplConfigurationDialog() {
     if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG)) {
-      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, "true");
+      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, String.valueOf(true));
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -62,8 +62,8 @@ public class PluginSettings implements MainViewModelProvider {
     return new MainViewModel();
   }
 
-  public static boolean shouldShowReplConfigurationDialog() {
-    return propertiesManager.getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
+  public static String shouldShowReplConfigurationDialog() {
+    return propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
   }
 
   /**
@@ -76,7 +76,8 @@ public class PluginSettings implements MainViewModelProvider {
   }
 
   /**
-   * Method that checks if the value is set (exists/non-empty etc.) and sets it to 'true'.
+   * Method that checks if the value is set (exists/non-empty etc.) and sets the {@link String}
+   * value to 'true'.
    */
   public static void initiateLocalSettingShowReplConfigurationDialog() {
     if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG)) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -62,12 +62,16 @@ public class PluginSettings implements MainViewModelProvider {
     return new MainViewModel();
   }
 
-  public static boolean isShowReplConfigurationDialog() {
+  public static boolean shouldShowReplConfigurationDialog() {
     return propertiesManager.getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
   }
 
-  //  todo consider to create a listener
-  public static void setShowReplConfigurationDialog(boolean showReplConfigDialog) {
+  /**
+   * Method to set property, responsible for showing REPL configuration window.
+   *
+   * @param showReplConfigDialog a {@link String} representing a boolean value of the flag.
+   */
+  public static void setShowReplConfigurationDialog(String showReplConfigDialog) {
     propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, showReplConfigDialog);
   }
 
@@ -76,7 +80,7 @@ public class PluginSettings implements MainViewModelProvider {
    */
   public static void initiateLocalSettingShowReplConfigurationDialog() {
     if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG)) {
-      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, true);
+      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, "true");
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
@@ -43,8 +43,8 @@ public class ReplConfigurationForm extends JPanel {
    */
   public ReplConfigurationForm(@NotNull ReplConfigurationFormModel model) {
     this.model = model;
-    dontShowThisWindowCheckBox.setSelected(
-        Boolean.parseBoolean(PluginSettings.shouldShowReplConfigurationDialog()));
+    dontShowThisWindowCheckBox
+        .setSelected(PluginSettings.getInstance().shouldShowReplConfigurationDialog());
 
     infoTextLabel.setText(INFOLABEL_TEXT);
 
@@ -80,8 +80,8 @@ public class ReplConfigurationForm extends JPanel {
   public void updateModel() {
     model.setTargetModuleName(requireNonNull(moduleComboBox.getSelectedItem()).toString());
     model.setModuleWorkingDirectory(workingDirectoryField.getText());
-    String chosenState = String.valueOf(!dontShowThisWindowCheckBox.isSelected());
-    PluginSettings.setShowReplConfigurationDialog(chosenState);
+    boolean chosenState = !dontShowThisWindowCheckBox.isSelected();
+    PluginSettings.getInstance().setShowReplConfigurationDialog(chosenState);
   }
 
   public void cancelReplStart() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
@@ -43,7 +43,7 @@ public class ReplConfigurationForm extends JPanel {
    */
   public ReplConfigurationForm(@NotNull ReplConfigurationFormModel model) {
     this.model = model;
-    dontShowThisWindowCheckBox.setSelected(PluginSettings.isShowReplConfigurationDialog());
+    dontShowThisWindowCheckBox.setSelected(PluginSettings.shouldShowReplConfigurationDialog());
 
     infoTextLabel.setText(INFOLABEL_TEXT);
 
@@ -79,7 +79,7 @@ public class ReplConfigurationForm extends JPanel {
   public void updateModel() {
     model.setTargetModuleName(requireNonNull(moduleComboBox.getSelectedItem()).toString());
     model.setModuleWorkingDirectory(workingDirectoryField.getText());
-    boolean chosenState = !dontShowThisWindowCheckBox.isSelected();
+    String chosenState = String.valueOf(!dontShowThisWindowCheckBox.isSelected());
     PluginSettings.setShowReplConfigurationDialog(chosenState);
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationForm.java
@@ -43,7 +43,8 @@ public class ReplConfigurationForm extends JPanel {
    */
   public ReplConfigurationForm(@NotNull ReplConfigurationFormModel model) {
     this.model = model;
-    dontShowThisWindowCheckBox.setSelected(PluginSettings.shouldShowReplConfigurationDialog());
+    dontShowThisWindowCheckBox.setSelected(
+        Boolean.parseBoolean(PluginSettings.shouldShowReplConfigurationDialog()));
 
     infoTextLabel.setText(INFOLABEL_TEXT);
 

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -50,7 +50,7 @@ class ReplAction extends RunConsoleAction {
   def setConfigurationConditionally(@NotNull project: Project,
                                     @NotNull module: Module,
                                     @NotNull configuration: ScalaConsoleRunConfiguration): Boolean = {
-    if (PluginSettings.isShowReplConfigurationDialog) {
+    if (PluginSettings.shouldShowReplConfigurationDialog) {
       val configModel = new ReplConfigurationFormModel(project, getModuleWorkDir(module), module.getName)
 
       createAndShowReplConfigurationDialog(configModel)

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -50,7 +50,7 @@ class ReplAction extends RunConsoleAction {
   def setConfigurationConditionally(@NotNull project: Project,
                                     @NotNull module: Module,
                                     @NotNull configuration: ScalaConsoleRunConfiguration): Boolean = {
-    if (PluginSettings.shouldShowReplConfigurationDialog.toBoolean) {
+    if (PluginSettings.getInstance().shouldShowReplConfigurationDialog) {
       val configModel = new ReplConfigurationFormModel(project, getModuleWorkDir(module), module.getName)
 
       createAndShowReplConfigurationDialog(configModel)

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -50,7 +50,7 @@ class ReplAction extends RunConsoleAction {
   def setConfigurationConditionally(@NotNull project: Project,
                                     @NotNull module: Module,
                                     @NotNull configuration: ScalaConsoleRunConfiguration): Boolean = {
-    if (PluginSettings.shouldShowReplConfigurationDialog) {
+    if (PluginSettings.shouldShowReplConfigurationDialog.toBoolean) {
       val configModel = new ReplConfigurationFormModel(project, getModuleWorkDir(module), module.getName)
 
       createAndShowReplConfigurationDialog(configModel)

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
@@ -18,7 +18,7 @@ public class PluginSettingsTest extends BasePlatformTestCase {
         PropertiesComponent.getInstance().isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
 
     //  when
-    PluginSettings.initiateLocalSettingShowReplConfigurationDialog();
+    PluginSettings.getInstance().initiateLocalSettingShowReplConfigurationDialog();
 
     //  then
     assertTrue("The state of the given setting is now set (to 'true').",

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
@@ -27,7 +27,7 @@ public class ReplConfigurationFormTest extends BasePlatformTestCase implements T
     assertEquals("Form contains the rights informative message",
         ReplConfigurationForm.INFOLABEL_TEXT, form.getInfoTextLabel().getText());
     assertEquals("Form correctly picks up negated flag for showing the config dialog",
-        Boolean.parseBoolean(PluginSettings.shouldShowReplConfigurationDialog()),
+        PluginSettings.getInstance().shouldShowReplConfigurationDialog(),
         form.getDontShowThisWindowCheckBox().isSelected());
   }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
@@ -27,7 +27,7 @@ public class ReplConfigurationFormTest extends BasePlatformTestCase implements T
     assertEquals("Form contains the rights informative message",
         ReplConfigurationForm.INFOLABEL_TEXT, form.getInfoTextLabel().getText());
     assertEquals("Form correctly picks up negated flag for showing the config dialog",
-        PluginSettings.isShowReplConfigurationDialog(),
+        PluginSettings.shouldShowReplConfigurationDialog(),
         form.getDontShowThisWindowCheckBox().isSelected());
   }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationFormTest.java
@@ -27,7 +27,7 @@ public class ReplConfigurationFormTest extends BasePlatformTestCase implements T
     assertEquals("Form contains the rights informative message",
         ReplConfigurationForm.INFOLABEL_TEXT, form.getInfoTextLabel().getText());
     assertEquals("Form correctly picks up negated flag for showing the config dialog",
-        PluginSettings.shouldShowReplConfigurationDialog(),
+        Boolean.parseBoolean(PluginSettings.shouldShowReplConfigurationDialog()),
         form.getDontShowThisWindowCheckBox().isSelected());
   }
 

--- a/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
+++ b/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
@@ -22,7 +22,7 @@ class ReplActionTest extends BasePlatformTestCase with TestHelperScala {
     val moduleWorkDir = action.getModuleWorkDir(module)
 
     //  only FALSE branch, as TRUE triggers UI
-    PluginSettings.setShowReplConfigurationDialog(false.toString);
+    PluginSettings.getInstance().setShowReplConfigurationDialog(false);
 
     //  when
     action.setConfigurationConditionally(project, module, configuration)

--- a/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
+++ b/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionTest.scala
@@ -22,7 +22,7 @@ class ReplActionTest extends BasePlatformTestCase with TestHelperScala {
     val moduleWorkDir = action.getModuleWorkDir(module)
 
     //  only FALSE branch, as TRUE triggers UI
-    PluginSettings.setShowReplConfigurationDialog(false);
+    PluginSettings.setShowReplConfigurationDialog(false.toString);
 
     //  when
     action.setConfigurationConditionally(project, module, configuration)


### PR DESCRIPTION
# Description

this now should fix

# Testing

- [ ] I created new unit tests
- [x] All unit tests pass
- [x] I have tested manually