### PR TITLE
Cleanup on plugin removal

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import fi.aalto.cs.apluscourses.presentation.MainViewModel;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.NotNull;
@@ -71,13 +72,16 @@ public class PluginSettings implements MainViewModelProvider {
     return new MainViewModel();
   }
 
+  /**
+   * Method (getter) to check the property, responsible for showing REPL configuration window.
+   */
   public boolean shouldShowReplConfigurationDialog() {
     return Boolean.parseBoolean(
         propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName()));
   }
 
   /**
-   * Method to set property, responsible for showing REPL configuration window.
+   * Method (setter) to set property, responsible for showing REPL configuration window.
    *
    * @param showReplConfigDialog a boolean value of the flag.
    */
@@ -100,11 +104,11 @@ public class PluginSettings implements MainViewModelProvider {
   }
 
   /**
-   * Method that unsets all the settings.
+   * Method that unsets all the local settings from {@link LocalSettingsNames}.
    */
   public void unsetLocalSettings() {
-    for (LocalSettingsNames settingsName : LocalSettingsNames.values()) {
-      propertiesManager.unsetValue(settingsName.getName());
-    }
+    Arrays.stream(LocalSettingsNames.values())
+        .map(LocalSettingsNames::getName)
+        .forEach(propertiesManager::unsetValue);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -15,9 +15,18 @@ import org.jetbrains.annotations.Nullable;
 
 public class PluginSettings implements MainViewModelProvider {
 
-  public interface LocalSettingsNames {
+  public enum LocalSettingsNames {
+    A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG("A+.showReplConfigDialog");
 
-    String A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG = "A+.showReplConfigDialog";
+    private final String name;
+
+    LocalSettingsNames(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
   }
 
   public static final String COURSE_CONFIGURATION_FILE_URL
@@ -63,7 +72,8 @@ public class PluginSettings implements MainViewModelProvider {
   }
 
   public boolean shouldShowReplConfigurationDialog() {
-    return Boolean.parseBoolean(propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
+    return Boolean.parseBoolean(
+        propertiesManager.getValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName()));
   }
 
   /**
@@ -74,16 +84,27 @@ public class PluginSettings implements MainViewModelProvider {
   public void setShowReplConfigurationDialog(boolean showReplConfigDialog) {
     propertiesManager
         //  a String explicitly
-        .setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, String.valueOf(showReplConfigDialog));
+        .setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName(),
+            String.valueOf(showReplConfigDialog));
   }
 
   /**
-   * Method that checks if the value is set (exists/non-empty etc.) and sets the {@link String}
+   * Method that checks if the values are is set (exists/non-empty etc.) and sets the {@link String}
    * value to 'true'.
    */
   public void initiateLocalSettingShowReplConfigurationDialog() {
-    if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG)) {
-      propertiesManager.setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG, String.valueOf(true));
+    if (!propertiesManager.isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName())) {
+      propertiesManager
+          .setValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName(), String.valueOf(true));
+    }
+  }
+
+  /**
+   * Method that unsets all the settings.
+   */
+  public void unsetLocalSettings() {
+    for (LocalSettingsNames settingsName : LocalSettingsNames.values()) {
+      propertiesManager.unsetValue(settingsName.getName());
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginLoadUnloadEventsListener.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginLoadUnloadEventsListener.java
@@ -5,12 +5,10 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import org.jetbrains.annotations.NotNull;
 
-public class PluginUnloadListener implements DynamicPluginListener {
+public class PluginLoadUnloadEventsListener implements DynamicPluginListener {
 
   @Override
   public void beforePluginUnload(@NotNull IdeaPluginDescriptor pluginDescriptor, boolean isUpdate) {
-    System.out.println("deleting plugin...");
-
     PluginSettings.getInstance().unsetLocalSettings();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginUnloadListener.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginUnloadListener.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.utils;
 
 import com.intellij.ide.plugins.DynamicPluginListener;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import org.jetbrains.annotations.NotNull;
 
 public class PluginUnloadListener implements DynamicPluginListener {
@@ -9,5 +10,7 @@ public class PluginUnloadListener implements DynamicPluginListener {
   @Override
   public void beforePluginUnload(@NotNull IdeaPluginDescriptor pluginDescriptor, boolean isUpdate) {
     System.out.println("deleting plugin...");
+
+    PluginSettings.getInstance().unsetLocalSettings();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginUnloadListener.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/PluginUnloadListener.java
@@ -1,0 +1,13 @@
+package fi.aalto.cs.apluscourses.intellij.utils;
+
+import com.intellij.ide.plugins.DynamicPluginListener;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import org.jetbrains.annotations.NotNull;
+
+public class PluginUnloadListener implements DynamicPluginListener {
+
+  @Override
+  public void beforePluginUnload(@NotNull IdeaPluginDescriptor pluginDescriptor, boolean isUpdate) {
+    System.out.println("deleting plugin...");
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -67,4 +67,7 @@
             <keyboard-shortcut first-keystroke="control shift D" keymap="$default"/>
         </action>
     </actions>
+    <applicationListeners>
+        <listener class="fi.aalto.cs.apluscourses.intellij.utils.PluginUnloadListener" topic="com.intellij.ide.plugins.DynamicPluginListener"/>
+    </applicationListeners>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,7 @@
         </action>
     </actions>
     <applicationListeners>
-        <listener class="fi.aalto.cs.apluscourses.intellij.utils.PluginUnloadListener" topic="com.intellij.ide.plugins.DynamicPluginListener"/>
+        <listener class="fi.aalto.cs.apluscourses.intellij.utils.PluginLoadUnloadEventsListener"
+                  topic="com.intellij.ide.plugins.DynamicPluginListener"/>
     </applicationListeners>
 </idea-plugin>

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettingsTest.java
@@ -12,16 +12,32 @@ public class PluginSettingsTest extends BasePlatformTestCase {
   public void testInitiateLocalSettingShowReplConfigurationDialogWorks() {
     //  given
     PropertiesComponent.getInstance()
-        .unsetValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG);
+        .unsetValue(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName());
 
     assertFalse("The state of the given setting is now 'unset'.",
-        PropertiesComponent.getInstance().isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
+        PropertiesComponent.getInstance()
+            .isValueSet(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName()));
 
     //  when
     PluginSettings.getInstance().initiateLocalSettingShowReplConfigurationDialog();
 
     //  then
     assertTrue("The state of the given setting is now set (to 'true').",
-        PropertiesComponent.getInstance().getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG));
+        PropertiesComponent.getInstance()
+            .getBoolean(A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName()));
+  }
+
+  @Test
+  public void testUnsetLocalSettings() {
+    //  given
+    PluginSettings.getInstance().initiateLocalSettingShowReplConfigurationDialog();
+
+    //  when
+    PluginSettings.getInstance().unsetLocalSettings();
+
+    //  then
+    assertNull("A+.showReplConfigDialog is successfully removed.",
+        PropertiesComponent.getInstance().getValue(
+            A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG.getName()));
   }
 }


### PR DESCRIPTION
# Description of the PR

+ lifecycle listener is now present
+ the only cleanup done for now is removing the local settings

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
