### PR TITLE
Add module id to the course file

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -18,14 +18,11 @@ import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
 import fi.aalto.cs.apluscourses.ui.IntelliJDialogs;
 import fi.aalto.cs.apluscourses.ui.base.Dialogs;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -190,8 +187,7 @@ public class CourseProjectAction extends AnAction implements DumbAware {
   private boolean tryCreateCourseFile(@NotNull Project project, @NotNull URL courseUrl) {
     try {
       if (createCourseFile) {
-        File courseFile = new APlusProject(project).getCourseFilePath().toFile();
-        FileUtils.writeStringToFile(courseFile, courseUrl.toString(), StandardCharsets.UTF_8);
+        new APlusProject(project).createCourseFile(courseUrl);
       }
       return true;
     } catch (IOException e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -18,14 +18,16 @@ import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
 import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,9 +90,12 @@ public class InitializationActivity implements Background {
     }
 
     try {
-      String contents = FileUtils.readFileToString(courseFile, StandardCharsets.UTF_8);
-      return new URL(contents);
-    } catch (IOException e) {
+      // TODO: the course file is written as UTF-8, ensure that this always works
+      JSONTokener tokenizer = new JSONTokener(new FileInputStream(courseFile));
+      JSONObject jsonObject = new JSONObject(tokenizer);
+      String url = jsonObject.getString("url");
+      return new URL(url);
+    } catch (IOException | JSONException e) {
       logger.error("Malformed project course tag file", e);
       return null;
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -17,8 +17,6 @@ import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationFileException;
 import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
 import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -26,8 +24,6 @@ import java.net.URL;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,17 +80,8 @@ public class InitializationActivity implements Background {
       return null;
     }
 
-    File courseFile = new APlusProject(project).getCourseFilePath().toFile();
-    if (!courseFile.isFile()) {
-      return null;
-    }
-
     try {
-      // TODO: the course file is written as UTF-8, ensure that this always works
-      JSONTokener tokenizer = new JSONTokener(new FileInputStream(courseFile));
-      JSONObject jsonObject = new JSONObject(tokenizer);
-      String url = jsonObject.getString("url");
-      return new URL(url);
+      return new APlusProject(project).getCourseFileUrl();
     } catch (IOException | JSONException e) {
       logger.error("Malformed project course tag file", e);
       return null;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
@@ -86,16 +86,19 @@ public class APlusProject {
   }
 
   private static final Object courseFileLock = new Object();
-  
+
   /**
-   * Adds an entry for the given module to the course file. If an entry exists with the same name,
-   * it is overwritten.
-   * @param module The module for which an entry is added.
-   * @throws IOException   If an IO error occurs (for an example, the course file doesn't exist).
+   * Adds an entry for the given module to the given course file. This method should only be used
+   * if when the default course file shouldn't be used (e.g. in testing). Prefer to use {@link
+   * APlusProject#addCourseFileEntry(Module)}.
+   * @param courseFile The file to which the entry is added(must already contain a valid JSON
+   *                   object).
+   * @param module     The module for which an entry is added.
+   * @throws IOException   If an IO error occurs (for an example, the file doesn't exist).
    * @throws JSONException If the existing JSON in the course file is malformed.
    */
-  public void addCourseFileEntry(@NotNull Module module) throws IOException {
-    File courseFile = getCourseFilePath().toFile();
+  public void addCourseFileEntry(@NotNull File courseFile, @NotNull Module module)
+      throws IOException {
     synchronized (courseFileLock) {
       JSONTokener tokenizer = new JSONTokener(new FileInputStream(courseFile));
       JSONObject jsonObject = new JSONObject(tokenizer);
@@ -111,6 +114,17 @@ public class APlusProject {
       jsonObject.put("modules", modulesObject);
       FileUtils.writeStringToFile(courseFile, jsonObject.toString(), StandardCharsets.UTF_8);
     }
+  }
+
+  /**
+   * Adds an entry for the given module to the course file. If an entry exists with the same name,
+   * it is overwritten.
+   * @param module The module for which an entry is added.
+   * @throws IOException   If an IO error occurs (for an example, the course file doesn't exist).
+   * @throws JSONException If the existing JSON in the course file is malformed.
+   */
+  public void addCourseFileEntry(@NotNull Module module) throws IOException {
+    addCourseFileEntry(getCourseFilePath().toFile(), module);
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
@@ -7,12 +7,20 @@ import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.util.messages.MessageBus;
 import fi.aalto.cs.apluscourses.model.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 
 public class APlusProject {
   @NotNull
@@ -29,7 +37,27 @@ public class APlusProject {
 
   @NotNull
   public Path getCourseFilePath() {
-    return getBasePath().resolve(Paths.get(Project.DIRECTORY_STORE_FOLDER, "a-plus-project"));
+    return getBasePath().resolve(Paths.get(Project.DIRECTORY_STORE_FOLDER, "a-plus-project.json"));
+  }
+
+  /**
+   * Creates a local course file containing the given URL. If a course file already exists (even if
+   * it was created with a different URL), this method does nothing and returns false.
+   * @param sourceUrl The URL that is added to the course file.
+   * @return True if the course file was created successfully, false if a course file already
+   *         exists.
+   * @throws IOException If an IO error occurs while creating the file.
+   */
+  public synchronized boolean createCourseFile(@NotNull URL sourceUrl) throws IOException {
+    File courseFile = getCourseFilePath().toFile();
+    if (courseFile.isFile()) {
+      return false;
+    }
+
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("url", sourceUrl.toString());
+    FileUtils.writeStringToFile(courseFile, jsonObject.toString(), StandardCharsets.UTF_8);
+    return true;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -91,10 +91,8 @@ public class IntelliJModelFactory implements ModelFactory {
   }
 
   @Override
-  public Module createModule(@NotNull String name, @NotNull URL url) {
-    // IntelliJ modules may already be present in the project or file system, so we determine the
-    // state at module creation here.
-    return new IntelliJModule(name, url, project);
+  public Module createModule(@NotNull String name, @NotNull URL url, @NotNull String versionId) {
+    return new IntelliJModule(name, url, versionId, project);
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
@@ -65,6 +65,7 @@ class IntelliJModule
   public void load() throws ComponentLoadException {
     try {
       WriteAction.runAndWait(new Loader(getProject(), getImlFile())::load);
+      project.addCourseFileEntry(this);
     } catch (Exception e) {
       throw new ComponentLoadException(getName(), e);
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
@@ -32,8 +32,11 @@ class IntelliJModule
   private final APlusProject project;
 
 
-  IntelliJModule(@NotNull String name, @NotNull URL url, @NotNull APlusProject project) {
-    super(name, url);
+  IntelliJModule(@NotNull String name,
+                 @NotNull URL url,
+                 @NotNull String versionId,
+                 @NotNull APlusProject project) {
+    super(name, url, versionId);
     this.project = project;
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -12,7 +12,7 @@ public interface ModelFactory {
                       @NotNull Map<String, String> requiredPlugins,
                       @NotNull Map<String, URL> resourceUrls);
 
-  Module createModule(@NotNull String name, @NotNull URL url);
+  Module createModule(@NotNull String name, @NotNull URL url, @NotNull String versionId);
 
   Library createLibrary(@NotNull String name);
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
@@ -49,4 +49,13 @@ public abstract class Module extends Component {
   public URL getUrl() {
     return url;
   }
+
+  /**
+   * Returns a string that uniquely identifies the version of this module. That is, a different
+   * version of the same module should return a different version string.
+   */
+  @NotNull
+  public String getVersionId() {
+    return "";
+  }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
@@ -10,24 +10,31 @@ public abstract class Module extends Component {
   @NotNull
   private final URL url;
 
+  @NotNull
+  private final String versionId;
+
   /**
    * Constructs a module with the given name and URL.
-   * @param name The name of the module.
-   * @param url The URL from which the module can be downloaded.
+   * @param name      The name of the module.
+   * @param url       The URL from which the module can be downloaded.
+   * @param versionId A string that uniquely identifies different versions of the same module.
    */
-  public Module(@NotNull String name, @NotNull URL url) {
+  public Module(@NotNull String name, @NotNull URL url, @NotNull String versionId) {
     super(name);
     this.url = url;
+    this.versionId = versionId;
   }
 
   /**
    * Returns a module constructed from the given JSON object. The object should contain the name of
-   * the module and the URL from which the module can be downloaded. Additional members in the
+   * the module and the URL from which the module can be downloaded. The object may optionally also
+   * contain a version id. Additional members in the
    * object don't cause any errors. Example of a valid JSON object:
    * <pre>
    * {
    *   "name": "My Module",
-   *   "url": "https://example.com"
+   *   "url": "https://example.com",
+   *   "id": "abc"
    * }
    * </pre>
    * @param jsonObject The JSON object containing information about a single module.
@@ -42,7 +49,11 @@ public abstract class Module extends Component {
       throws MalformedURLException {
     String name = jsonObject.getString("name");
     URL url = new URL(jsonObject.getString("url"));
-    return factory.createModule(name, url);
+    String versionId = jsonObject.optString("id");
+    if (versionId == null) {
+      versionId = "";
+    }
+    return factory.createModule(name, url, versionId);
   }
 
   @NotNull
@@ -56,6 +67,6 @@ public abstract class Module extends Component {
    */
   @NotNull
   public String getVersionId() {
-    return "";
+    return versionId;
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/APlusProjectTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/APlusProjectTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtilRt;
-import com.intellij.testFramework.HeavyPlatformTestCase;
+
 import fi.aalto.cs.apluscourses.model.Component;
 
 import java.io.File;
@@ -25,7 +25,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class APlusProjectTest extends HeavyPlatformTestCase {
+public class APlusProjectTest {
 
   @Test
   public void testGetCourseFilePath() {
@@ -68,24 +68,25 @@ public class APlusProjectTest extends HeavyPlatformTestCase {
 
     IntelliJModelExtensions.TestComponent loadedComponent =
         new IntelliJModelExtensions.TestComponent(loadedComponentName, new Object());
-    assertEquals(Component.LOADED, project.resolveComponentState(loadedComponent));
+    Assert.assertEquals(Component.LOADED, project.resolveComponentState(loadedComponent));
 
     IntelliJModelExtensions.TestComponent fetchedComponent =
         new IntelliJModelExtensions.TestComponent(fetchedComponentName, null);
-    assertEquals(Component.FETCHED, project.resolveComponentState(fetchedComponent));
+    Assert.assertEquals(Component.FETCHED, project.resolveComponentState(fetchedComponent));
 
     IntelliJModelExtensions.TestComponent notInstalledComponent =
         new IntelliJModelExtensions.TestComponent(notInstalledComponentName, null);
-    assertEquals(Component.NOT_INSTALLED, project.resolveComponentState(notInstalledComponent));
+    Assert.assertEquals(Component.NOT_INSTALLED,
+        project.resolveComponentState(notInstalledComponent));
 
     IntelliJModelExtensions.TestComponent errorComponent =
         new IntelliJModelExtensions.TestComponent(errorComponentName, new Object());
-    assertEquals(Component.ERROR, project.resolveComponentState(errorComponent));
+    Assert.assertEquals(Component.ERROR, project.resolveComponentState(errorComponent));
   }
 
   @Test
   public void testAddCourseFileEntry() throws IOException, InterruptedException {
-    final int numThreads = 8;
+    final int numThreads = 16;
 
     Project project = mock(Project.class);
     APlusProject aplusProject = new APlusProject(project);
@@ -102,7 +103,7 @@ public class APlusProjectTest extends HeavyPlatformTestCase {
       Runnable runnable = () -> {
         try {
           aplusProject.addCourseFileEntry(temp, module);
-        } catch (IOException ignored) {
+        } catch (IOException e) {
           failed.set(true);
         }
       };
@@ -116,7 +117,7 @@ public class APlusProjectTest extends HeavyPlatformTestCase {
     }
 
     if (failed.get()) {
-      fail("IOException thrown from APlusProject#addCourseFileEntry");
+      Assert.fail("IOException thrown from APlusProject#addCourseFileEntry");
     }
 
     JSONObject jsonObject

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/APlusProjectTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/APlusProjectTest.java
@@ -22,7 +22,7 @@ public class APlusProjectTest {
     APlusProject aplusProject = new APlusProject(project);
 
     Assert.assertEquals("The course file path should be correct",
-        Paths.get("test", Project.DIRECTORY_STORE_FOLDER, "a-plus-project"),
+        Paths.get("test", Project.DIRECTORY_STORE_FOLDER, "a-plus-project.json"),
         aplusProject.getCourseFilePath());
   }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -44,8 +44,8 @@ public class CourseTest {
 
   @Test
   public void testGetModule() throws MalformedURLException, NoSuchComponentException {
-    Module module1 = new ModelExtensions.TestModule("Test Module", new URL("https://example.com"));
-    Module module2 = new ModelExtensions.TestModule("Awesome Module", new URL("https://slack.com"));
+    Module module1 = new ModelExtensions.TestModule("Test Module");
+    Module module2 = new ModelExtensions.TestModule("Awesome Module");
     Course course = new Course("", Arrays.asList(module1, module2), Collections.emptyList(),
         Collections.emptyMap(), Collections.emptyMap());
     assertSame("Course#getModule should return the correct module",

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -78,11 +78,11 @@ public class ModelExtensions {
     }
 
     public TestModule(@NotNull String name) {
-      this(name, testURL);
+      this(name, testURL, "");
     }
 
-    public TestModule(@NotNull String name, @NotNull URL url) {
-      super(name, url);
+    public TestModule(@NotNull String name, @NotNull URL url, @NotNull String versionId) {
+      super(name, url, versionId);
     }
 
     @NotNull
@@ -165,8 +165,8 @@ public class ModelExtensions {
     }
 
     @Override
-    public Module createModule(@NotNull String name, @NotNull URL url) {
-      return new TestModule(name, url);
+    public Module createModule(@NotNull String name, @NotNull URL url, @NotNull String versionId) {
+      return new TestModule(name, url, versionId);
     }
 
     @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModuleTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModuleTest.java
@@ -16,21 +16,35 @@ public class ModuleTest {
   public void testCreateModule() throws MalformedURLException {
     String name = "Awesome module";
     URL url = new URL("https://example.com");
-    Module module = new ModelExtensions.TestModule(name, url);
+    String id = "cool id";
+    Module module = new ModelExtensions.TestModule(name, url, id);
     assertEquals("The name of the module should be the same as that given to the constructor",
         name, module.getName());
     assertEquals("The URL of the module should be the same as that given to the constructor",
         url, module.getUrl());
+    assertEquals("The id of the module should be the same as that given to the constructor",
+        id, module.getVersionId());
   }
 
   @Test
   public void testCreateModuleFromJsonObject() throws MalformedURLException {
-    JSONObject jsonObject = new JSONObject("{\"name\":\"Name\",\"url\":\"https://aalto.fi\"}");
+    JSONObject jsonObject
+        = new JSONObject("{\"name\":\"Name\",\"url\":\"https://aalto.fi\",\"id\":\"abc\"}");
     Module module = Module.fromJsonObject(jsonObject, MODEL_FACTORY);
     assertEquals("The name of the module should be the same as that in the JSON object",
         "Name", module.getName());
     assertEquals("The URL of the module should be the same as that in the JSON object",
         new URL("https://aalto.fi"), module.getUrl());
+    assertEquals("The id of the module should be the same as that in the JSON object",
+        "abc", module.getVersionId());
+  }
+
+  @Test
+  public void testCreateModuleFromJsonObjectWithoutId() throws MalformedURLException {
+    JSONObject jsonObject
+        = new JSONObject("{\"name\":\"Name\",\"url\":\"https://example.org\"}");
+    Module module = Module.fromJsonObject(jsonObject, MODEL_FACTORY);
+    assertEquals("The module id should default to an empty string", "", module.getVersionId());
   }
 
   @Test(expected = JSONException.class)

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/module/ModuleListElementViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/module/ModuleListElementViewModelTest.java
@@ -35,7 +35,7 @@ public class ModuleListElementViewModelTest {
   public void testNameAndUrl() throws MalformedURLException {
     String name = "Wanda";
     String url = "https://example.com/wanda";
-    Module module = new ModelExtensions.TestModule(name, new URL(url));
+    Module module = new ModelExtensions.TestModule(name, new URL(url), "");
     ModuleListElementViewModel moduleViewModel = new ModuleListElementViewModel(module);
     assertEquals("getName() should return module's name",
         name, moduleViewModel.getName());


### PR DESCRIPTION
# Description of the PR
Adds a version ID to the `Module` class, which gets added to the course file (`a-plus-project.json`) when a module is imported. The module id is optional in the course configuration file and the modules default to an empty string id.

The current implementation uses a static lock for all instances of `APlusProject`, as I am not sure if we only have one instance of `APlusProject` per IntelliJ project. The current implementation also parses the course file again every time a new entry is added. Caching the previously parsed JSON object should be easy, as long as the `APlusProject` instance is the same.  The current locking is pretty hacky and should be improved.  

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [x] Not yet. I will do it next.
- [ ] Not relevant
