### PR TITLE
Add custom settings to workspace.xml with project settings import

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -299,3 +299,29 @@ a manual testing manual. Marked with a github issue label "manual testing".
     </ol>
   </div>
 </details>
+<details>
+  <summary>
+    <a href="https://github.com/Aalto-LeTech/intellij-plugin/issues/130">
+      Add AUTO_SHOW_ERRORS_IN_EDITOR="false" to workspace.xml when project settings are imported #130
+    </a>
+  </summary>
+  <div>
+    <h5>Importing project settings</h5>
+    <ol>
+      <li>Use the "Turn Project Into A+ Course Project" menu item to import project settings.</li>
+      <li>Open the file <code>.idea/workspace.xml</code>.</li>
+      <li>
+        Ensure that it contains the following:
+        <pre>
+&lt;component name="CompilerWorkspaceConfiguration">
+  &lt;option name="AUTO_SHOW_ERRORS_IN_EDITOR" value="false" />
+&lt;/component></pre>
+      </li>
+      <li>Use the "Turn Project Into A+ Course Project" menu item again.</li>
+      <li>
+        If <code>workspace.xml</code> now contains option entry multiple times, save the
+        <code>workspace.xml</code> file and ensure that the duplicate gets removed.
+      </li>
+    </ol>
+  </div>
+</details>

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
@@ -124,14 +124,17 @@ public class SettingsImporterImpl implements SettingsImporter {
       Node projectNode = document.getDocumentElement();
 
       // Check if a component with the given name already exists
-      Node compilerConfigurationNode = DomUtil.findChildNodeWithAttribute(projectNode,
-          "component", "name", WORKSPACE_XML_COMPONENT_NAME);
-
-      if (compilerConfigurationNode == null) {
+      List<Node> componentMatches = DomUtil.getNodesFromXPath(
+          "//component[@name=\"" + WORKSPACE_XML_COMPONENT_NAME + "\"]", projectNode);
+      Node compilerConfigurationNode;
+      if (componentMatches.isEmpty()) {
         Element compilerConfigurationElement = document.createElement("component");
         compilerConfigurationElement.setAttribute("name", WORKSPACE_XML_COMPONENT_NAME);
         compilerConfigurationNode = compilerConfigurationElement;
         projectNode.appendChild(compilerConfigurationNode);
+      } else {
+        // There should only be one match, otherwise the workspace.xml file is in a weird state
+        compilerConfigurationNode = componentMatches.get(0);
       }
 
       Element option = document.createElement("option");

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
@@ -3,12 +3,12 @@ package fi.aalto.cs.apluscourses.intellij.model;
 import com.intellij.ide.startup.StartupActionScriptManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.updateSettings.impl.UpdateSettings;
 import com.intellij.openapi.util.io.FileUtilRt;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
+import fi.aalto.cs.apluscourses.utils.DomUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -20,9 +20,12 @@ import java.util.stream.Collectors;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.FileHeader;
 import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
 public class SettingsImporterImpl implements SettingsImporter {
-
 
   /**
    * Downloads the course IDE settings ZIP file to a temporary file. Also adds IDEA startup actions
@@ -82,6 +85,16 @@ public class SettingsImporterImpl implements SettingsImporter {
     File settingsZip = FileUtilRt.createTempFile(project.getName() + "-settings", ".zip");
     CoursesClient.fetchZip(settingsUrl, settingsZip);
     ZipFile zipFile = new ZipFile(settingsZip);
+
+    extractZipTo(zipFile, settingsPath);
+
+    Path workspaceXmlPath = settingsPath.resolve("workspace.xml");
+    Document workspaceXml = createCustomWorkspaceXml(workspaceXmlPath);
+    DomUtil.writeDocumentToFile(workspaceXml, workspaceXmlPath.toFile());
+  }
+
+  private static void extractZipTo(@NotNull ZipFile zipFile, @NotNull Path target)
+      throws IOException {
     List<String> fileNames = zipFile
         .getFileHeaders()
         .stream()
@@ -91,11 +104,46 @@ public class SettingsImporterImpl implements SettingsImporter {
 
     for (String fileName : fileNames) {
       Path path = Paths.get(fileName);
+      // The ZIP contains a .idea directory with all of the settings files. We want to extract the
+      // files to the .idea directory without the .idea prefix, as otherwise we would end up with
+      // .idea/.idea/<settings_files>.
       Path pathWithoutRoot = path.subpath(1, path.getNameCount());
-      zipFile.extractFile(path.toString(), settingsPath.toString(), pathWithoutRoot.toString());
+      zipFile.extractFile(path.toString(), target.toString(), pathWithoutRoot.toString());
     }
-
-    ProjectManager.getInstance().reloadProject(project);
   }
+
+  private static final String WORKSPACE_XML_COMPONENT_NAME = "CompilerWorkspaceConfiguration";
+  private static final String WORKSPACE_XML_OPTION_NAME = "AUTO_SHOW_ERRORS_IN_EDITOR";
+  private static final String WORKSPACE_XML_OPTION_VALUE = "false";
+
+  @NotNull
+  private static Document createCustomWorkspaceXml(@NotNull Path workspaceXmlPath) throws
+      IOException {
+    try {
+      Document document = DomUtil.parse(workspaceXmlPath.toFile());
+      Node projectNode = document.getDocumentElement();
+
+      // Check if a component with the given name already exists
+      Node compilerConfigurationNode = DomUtil.findChildNodeWithAttribute(projectNode,
+          "component", "name", WORKSPACE_XML_COMPONENT_NAME);
+
+      if (compilerConfigurationNode == null) {
+        Element compilerConfigurationElement = document.createElement("component");
+        compilerConfigurationElement.setAttribute("name", WORKSPACE_XML_COMPONENT_NAME);
+        compilerConfigurationNode = compilerConfigurationElement;
+        projectNode.appendChild(compilerConfigurationNode);
+      }
+
+      Element option = document.createElement("option");
+      option.setAttribute("name", WORKSPACE_XML_OPTION_NAME);
+      option.setAttribute("value", WORKSPACE_XML_OPTION_VALUE);
+      compilerConfigurationNode.appendChild(option);
+      return document;
+    } catch (SAXException ex) {
+      // If workspace.xml is malformed, then something is seriously wrong...
+      throw new IllegalStateException();
+    }
+  }
+
 
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImpl.java
@@ -116,8 +116,13 @@ public class SettingsImporterImpl implements SettingsImporter {
   private static final String WORKSPACE_XML_OPTION_NAME = "AUTO_SHOW_ERRORS_IN_EDITOR";
   private static final String WORKSPACE_XML_OPTION_VALUE = "false";
 
+  /**
+   * Parses the XML file (usually the workspace.xml file stored in .idea) at the given path and
+   * returns a {@link Document} with file contents and an additional setting added.
+   * @param workspaceXmlPath The path pointing to the XML file.
+   */
   @NotNull
-  private static Document createCustomWorkspaceXml(@NotNull Path workspaceXmlPath) throws
+  public static Document createCustomWorkspaceXml(@NotNull Path workspaceXmlPath) throws
       IOException {
     try {
       Document document = DomUtil.parse(workspaceXmlPath.toFile());

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
@@ -23,7 +23,6 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -112,30 +111,6 @@ public class DomUtil {
     try (InputStream stream = new FileInputStream(file)) {
       return getNodesFromXPath(xpath, stream);
     }
-  }
-
-  /**
-   * Iterates through the immediate children of the given parent and returns the first node with the
-   * given name, attribute, and attribute value, or null if such a node isn't found.
-   * @param parent         The children of this node are examined.
-   * @param tagName        The name of the tag of the child node.
-   * @param attributeName  The name of an attribute that the child node must have.
-   * @param attributeValue The value corresponding to the attribute name that the child must have.
-   * @return The first node with the given tag name, attribute name, and attribute value, or null
-   *         if such a node isn't found.
-   */
-  @Nullable
-  public static Node findChildNodeWithAttribute(@NotNull Node parent,
-                                                @NotNull String tagName,
-                                                @NotNull String attributeName,
-                                                @NotNull String attributeValue) {
-
-    List<Node> matches = getNodesFromXPath(
-        "//" + tagName + "[@" + attributeName + "=\"" + attributeValue + "\"]", parent);
-    if (matches.isEmpty()) {
-      return null;
-    }
-    return matches.get(0);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
@@ -13,7 +13,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
@@ -27,7 +27,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -122,30 +121,21 @@ public class DomUtil {
    * @param tagName        The name of the tag of the child node.
    * @param attributeName  The name of an attribute that the child node must have.
    * @param attributeValue The value corresponding to the attribute name that the child must have.
+   * @return The first node with the given tag name, attribute name, and attribute value, or null
+   *         if such a node isn't found.
    */
   @Nullable
   public static Node findChildNodeWithAttribute(@NotNull Node parent,
                                                 @NotNull String tagName,
                                                 @NotNull String attributeName,
                                                 @NotNull String attributeValue) {
-    NodeList children = parent.getChildNodes();
-    for (int i = 0; i < children.getLength(); ++i) {
-      Node child = children.item(i);
-      if (!child.getNodeName().equals(tagName)) {
-        continue;
-      }
 
-      NamedNodeMap attributes = child.getAttributes();
-      if (attributes == null) {
-        continue;
-      }
-
-      Node attribute = attributes.getNamedItem(attributeName);
-      if (attribute != null && attribute.getNodeValue().equals(attributeValue)) {
-        return child;
-      }
+    List<Node> matches = getNodesFromXPath(
+        "//" + tagName + "[@" + attributeName + "=\"" + attributeValue + "\"]", parent);
+    if (matches.isEmpty()) {
+      return null;
     }
-    return null;
+    return matches.get(0);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/DomUtil.java
@@ -37,6 +37,7 @@ public class DomUtil {
   private static ConcurrentMap<String, XPathExpression> xPathCache;
   private static final XPathFactory xPathFactory;
   private static final DocumentBuilderFactory documentBuilderFactory;
+  private static final TransformerFactory transformerFactory;
 
   static {
     xPathCache = new ConcurrentHashMap<>();
@@ -44,9 +45,13 @@ public class DomUtil {
     xPathFactory = XPathFactory.newInstance();
 
     documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+    transformerFactory = TransformerFactory.newInstance();
     try {
       documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
       documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
     } catch (IllegalArgumentException e) {
       logger.warn("Could not set XXE restrictions for DOM tools because the platform does not "
           + "support them.");
@@ -156,8 +161,7 @@ public class DomUtil {
     Source source = new DOMSource(document);
     StreamResult result = new StreamResult(out);
     try {
-      Transformer transformer = TransformerFactory.newInstance().newTransformer();
-      transformer.transform(source, result);
+      transformerFactory.newTransformer().transform(source, result);
     } catch (TransformerException ex) {
       throw new IOException(ex);
     }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
@@ -31,4 +31,23 @@ public class SettingsImporterImplTest {
         optionMatches.isEmpty());
   }
 
+  @Test
+  public void testCreateCustomWorkspaceXmlWithExistingComponent() throws IOException {
+    File temp = FileUtilRt.createTempFile("xml", "xml", true);
+    FileUtils.writeStringToFile(temp, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<project version=\"4\"><component name=\"CompilerWorkspaceConfiguration\"><option name="
+        + "\"AUTO_SHOW_ERRORS_IN_EDITOR\" value=\"true\"/></component></project>",
+        StandardCharsets.UTF_8);
+    Document document = SettingsImporterImpl.createCustomWorkspaceXml(temp.toPath());
+    List<Node> componentMatches = DomUtil.getNodesFromXPath(
+        "//component[@name=\"CompilerWorkspaceConfiguration\"]", document);
+    Assert.assertFalse("The customized workspace.xml should contain the correct component node",
+        componentMatches.isEmpty());
+    List<Node> optionMatches = DomUtil.getNodesFromXPath(
+        "//option[@name=\"AUTO_SHOW_ERRORS_IN_EDITOR\" and @value=\"false\"]",
+        componentMatches.get(0));
+    Assert.assertFalse("The component node should contain the correct setting",
+        optionMatches.isEmpty());
+  }
+
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
@@ -1,0 +1,34 @@
+package fi.aalto.cs.apluscourses.intellij.model;
+
+import com.intellij.openapi.util.io.FileUtilRt;
+import fi.aalto.cs.apluscourses.utils.DomUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+public class SettingsImporterImplTest {
+
+  @Test
+  public void testCreateCustomWorkspaceXml() throws IOException {
+    File temp = FileUtilRt.createTempFile("xml", "xml", true);
+    FileUtils.writeStringToFile(temp, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<project version=\"4\"></project>", StandardCharsets.UTF_8);
+    Document document = SettingsImporterImpl.createCustomWorkspaceXml(temp.toPath());
+    List<Node> componentMatches = DomUtil.getNodesFromXPath(
+        "//component[@name=\"CompilerWorkspaceConfiguration\"]", document);
+    Assert.assertFalse("The customized workspace.xml should contain the correct component node",
+        componentMatches.isEmpty());
+    List<Node> optionMatches = DomUtil.getNodesFromXPath(
+        "//option[@name=\"AUTO_SHOW_ERRORS_IN_EDITOR\" and @value=\"false\"]",
+        componentMatches.get(0));
+    Assert.assertFalse("The component node should contain the correct setting",
+        optionMatches.isEmpty());
+  }
+
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporterImplTest.java
@@ -50,4 +50,12 @@ public class SettingsImporterImplTest {
         optionMatches.isEmpty());
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void testCreateCustomWorkspaceXmlWithMalformedXml() throws IOException {
+    File temp = FileUtilRt.createTempFile("malformed", "xml", true);
+    FileUtils.writeStringToFile(temp, "<?xml version\"1.0\" encoding=\"UTF-8\"?><component>",
+        StandardCharsets.UTF_8);
+    SettingsImporterImpl.createCustomWorkspaceXml(temp.toPath());
+  }
+
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/utils/DomUtilTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/DomUtilTest.java
@@ -1,10 +1,18 @@
 package fi.aalto.cs.apluscourses.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import com.intellij.openapi.util.io.FileUtilRt;
+
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
@@ -24,5 +32,22 @@ public class DomUtilTest {
         "bar", nodes.get(1).getTextContent());
     assertEquals("The text content of the third node should be 'baz'",
         "baz", nodes.get(2).getTextContent());
+  }
+
+  @Test
+  public void testWriteDocumentToFile() throws IOException, SAXException {
+    File temp = FileUtilRt.createTempFile("test", "xml", true);
+    FileUtils.writeStringToFile(temp, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root />",
+        StandardCharsets.UTF_8);
+
+    Document document = DomUtil.parse(temp);
+    document.getDocumentElement().appendChild(document.createElement("child"));
+
+    DomUtil.writeDocumentToFile(document, temp);
+
+    document = DomUtil.parse(temp);
+
+    List<Node> nodes = DomUtil.getNodesFromXPath("//child", document);
+    assertFalse("The file should contain the correct XML", nodes.isEmpty());
   }
 }


### PR DESCRIPTION
# Description of the PR

Edits `workspace.xml` when project settings are imported. Adds a component with the name `CompilerWorkspaceConfiguration`, that contains an option with the name `AUTO_SHOW_ERRORS_IN_EDITOR` and sets its value to `false`. The custom settings are completely hard coded, and we should explore how this information could be included in the course configuration file.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [x] Yes
- [ ] Not yet. I will do it next.
- [ ] Not relevant
