### PR TITLE
A+.MENU_ACTIONS bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'scala'
     id 'checkstyle'
     id 'com.github.alisiikh.scalastyle' version '3.3.1'
-    id 'org.jetbrains.intellij' version '0.4.21'
+    id 'org.jetbrains.intellij' version '0.4.16'
     id "org.sonarqube" version "2.8"
     id 'jacoco'
     id 'maven-publish'


### PR DESCRIPTION
From testing it seems that the bug was introduced when the `org.jetbrains.intellij` plugin was updated from version `0.4.16` to `0.4.18`. The same bug also occurs on version `0.4.17`, so I suggest we revert back to version `0.4.16` for now and figure out later why our plugin breaks with newer versions.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
