### PR TITLE
Get rid of module dialog

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -42,12 +42,22 @@ class IntelliJCourse extends Course {
                         @NotNull String name,
                         @NotNull List<Module> modules,
                         @NotNull List<Library> libraries,
+                        @NotNull Map<Long, Map<String, String>> exerciseModules,
                         @NotNull Map<String, String> requiredPlugins,
                         @NotNull Map<String, URL> resourceUrls,
                         @NotNull List<String> autoInstallComponentNames,
                         @NotNull APlusProject project,
                         @NotNull CommonLibraryProvider commonLibraryProvider) {
-    super(id, name, modules, libraries, requiredPlugins, resourceUrls, autoInstallComponentNames);
+    super(
+        id,
+        name,
+        modules,
+        libraries,
+        exerciseModules,
+        requiredPlugins,
+        resourceUrls,
+        autoInstallComponentNames
+    );
 
     this.project = project;
     this.commonLibraryProvider = commonLibraryProvider;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -32,13 +32,14 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull String name,
                              @NotNull List<Module> modules,
                              @NotNull List<Library> libraries,
+                             @NotNull Map<Long, Map<String, String>> exerciseModules,
                              @NotNull Map<String, String> requiredPlugins,
                              @NotNull Map<String, URL> resourceUrls,
                              @NotNull List<String> autoInstallComponentNames) {
 
     IntelliJCourse course =
-        new IntelliJCourse(id, name, modules, libraries, requiredPlugins, resourceUrls,
-            autoInstallComponentNames, project, new CommonLibraryProvider(project));
+        new IntelliJCourse(id, name, modules, libraries, exerciseModules, requiredPlugins,
+            resourceUrls, autoInstallComponentNames, project, new CommonLibraryProvider(project));
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/MissingModuleNotification.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/MissingModuleNotification.java
@@ -1,0 +1,21 @@
+package fi.aalto.cs.apluscourses.intellij.notifications;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import org.jetbrains.annotations.NotNull;
+
+public class MissingModuleNotification extends Notification {
+
+  /**
+   * Construct a missing module notification that explains that a module with the given name
+   * couldn't be found.
+   */
+  public MissingModuleNotification(@NotNull String moduleName) {
+    super(
+        "A+",
+        "Could not find file",
+        "A+ Courses plugin couldn't find the module " + moduleName + ".",
+        NotificationType.ERROR);
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -1,8 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
-import fi.aalto.cs.apluscourses.utils.ResourceException;
-import fi.aalto.cs.apluscourses.utils.Resources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -39,6 +39,9 @@ public class Course implements ComponentSource {
   @NotNull
   private final List<Library> libraries;
 
+  @NotNull
+  private final Map<Long, Map<String, String>> exerciseModules;
+
   // Maps ids of required plugins to the names of required plugins.
   @NotNull
   private final Map<String, String> requiredPlugins;
@@ -66,25 +69,20 @@ public class Course implements ComponentSource {
                 @NotNull String name,
                 @NotNull List<Module> modules,
                 @NotNull List<Library> libraries,
+                @NotNull Map<Long, Map<String, String>> exerciseModules,
                 @NotNull Map<String, String> requiredPlugins,
                 @NotNull Map<String, URL> resourceUrls,
                 @NotNull List<String> autoInstallComponentNames) {
     this.id = id;
     this.name = name;
     this.modules = modules;
+    this.libraries = libraries;
+    this.exerciseModules = exerciseModules;
     this.requiredPlugins = requiredPlugins;
     this.resourceUrls = resourceUrls;
-    this.libraries = libraries;
     this.autoInstallComponentNames = autoInstallComponentNames;
     components = Stream.concat(modules.stream(), libraries.stream())
         .collect(Collectors.toMap(Component::getName, Function.identity()));
-  }
-
-  @NotNull
-  public static Course fromResource(@NotNull String resourceName, @NotNull ModelFactory factory)
-      throws ResourceException, MalformedCourseConfigurationFileException {
-    Reader reader = new InputStreamReader(Resources.DEFAULT.getStream(resourceName));
-    return fromConfigurationData(reader, resourceName, factory);
   }
 
   /**
@@ -120,12 +118,14 @@ public class Course implements ComponentSource {
     String courseId = getCourseId(jsonObject, sourcePath);
     String courseName = getCourseName(jsonObject, sourcePath);
     List<Module> courseModules = getCourseModules(jsonObject, sourcePath, factory);
+    Map<Long, Map<String, String>> exerciseModules
+        = getCourseExerciseModules(jsonObject, sourcePath);
     Map<String, String> requiredPlugins = getCourseRequiredPlugins(jsonObject, sourcePath);
     Map<String, URL> resourceUrls = getCourseResourceUrls(jsonObject, sourcePath);
     List<String> autoInstallComponentNames
         = getCourseAutoInstallComponentNames(jsonObject, sourcePath);
     return factory.createCourse(courseId, courseName, courseModules, Collections.emptyList(),
-        requiredPlugins, resourceUrls, autoInstallComponentNames);
+        exerciseModules, requiredPlugins, resourceUrls, autoInstallComponentNames);
   }
 
   /**
@@ -189,6 +189,16 @@ public class Course implements ComponentSource {
   @NotNull
   public Collection<Component> getComponents() {
     return components.values();
+  }
+
+  /**
+   * Returns a mapping of exercise IDs to modules. The keys are exercise IDs, and the values are
+   * maps from language codes to module names. Note, that some exercises use modules that are not in
+   * the course configuration file, so the modules may not be in {@link Course#getModules}.
+   */
+  @NotNull
+  public Map<Long, Map<String, String>> getExerciseModules() {
+    return Collections.unmodifiableMap(exerciseModules);
   }
 
   /**
@@ -290,6 +300,34 @@ public class Course implements ComponentSource {
       }
     }
     return modules;
+  }
+
+  @NotNull
+  private static Map<Long, Map<String, String>> getCourseExerciseModules(@NotNull JSONObject object,
+                                                                         @NotNull String source)
+      throws MalformedCourseConfigurationFileException {
+    Map<Long, Map<String, String>> exerciseModules = new HashMap<>();
+    JSONObject exerciseModulesJson = object.optJSONObject("exerciseModules");
+    if (exerciseModulesJson == null) {
+      return exerciseModules;
+    }
+
+    try {
+      Iterable<String> keys = exerciseModulesJson::keys;
+      for (String exerciseId : keys) {
+        JSONObject modules = exerciseModulesJson.getJSONObject(exerciseId);
+        Map<String, String> languageToModule = new HashMap<>();
+        Iterable<String> languages = modules::keys;
+        for (String language : languages) {
+          languageToModule.put(language, modules.getString(language));
+        }
+        exerciseModules.put(Long.valueOf(exerciseId), languageToModule);
+      }
+      return exerciseModules;
+    } catch (JSONException e) {
+      throw new MalformedCourseConfigurationFileException(source,
+          "Malformed \"exerciseModules\" object", e);
+    }
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -10,6 +10,7 @@ public interface ModelFactory {
                       @NotNull String name,
                       @NotNull List<Module> modules,
                       @NotNull List<Library> libraries,
+                      @NotNull Map<Long, Map<String, String>> exerciseModules,
                       @NotNull Map<String, String> requiredPlugins,
                       @NotNull Map<String, URL> resourceUrls,
                       @NotNull List<String> autoInstallComponentNames);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
@@ -116,7 +116,8 @@ public class CourseProjectActionTest {
     doReturn(project).when(anActionEvent).getProject();
 
     emptyCourse = new Course("ID","EMPTY", Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyList());
 
     settingsImporter = new DummySettingsImporter();
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/ImportModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/ImportModuleActionTest.java
@@ -58,6 +58,7 @@ public class ImportModuleActionTest {
         Collections.emptyList(),
         Collections.emptyMap(),
         Collections.emptyMap(),
+        Collections.emptyMap(),
         Collections.emptyList());
     mainViewModel.courseViewModel.set(new CourseViewModel(course));
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
@@ -35,7 +35,8 @@ public class IntelliJCourseTest {
     CommonLibraryProvider commonLibraryProvider = new CommonLibraryProvider(project);
     IntelliJCourse course = new IntelliJCourse(id, name,
         Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(),
-        Collections.emptyMap(), Collections.emptyList(), project, commonLibraryProvider);
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), project,
+        commonLibraryProvider);
     assertEquals(id, course.getId());
     assertEquals(name, course.getName());
     assertSame(project, course.getProject());
@@ -63,7 +64,7 @@ public class IntelliJCourseTest {
 
     IntelliJCourse course = new IntelliJCourse("cool id", "testProject",
         modules, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyList(), project, commonLibraryProvider);
+        Collections.emptyMap(), Collections.emptyList(), project, commonLibraryProvider);
 
     Collection<Component> components1 = course.getComponents();
     assertEquals(1, components1.size());
@@ -92,7 +93,8 @@ public class IntelliJCourseTest {
 
     IntelliJCourse course = new IntelliJCourse("courseId", "testtesttest",
         modules, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyList(), mock(APlusProject.class), mock(CommonLibraryProvider.class));
+        Collections.emptyMap(), Collections.emptyList(), mock(APlusProject.class),
+        mock(CommonLibraryProvider.class));
 
     assertSame(module, course.getComponentIfExists(file));
   }
@@ -111,7 +113,8 @@ public class IntelliJCourseTest {
     IntelliJCourse course = new IntelliJCourse("testId", "testProject",
         Stream.of(new ModelExtensions.TestModule(moduleName)).collect(Collectors.toList()),
         Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyList(), mock(APlusProject.class), mock(CommonLibraryProvider.class));
+        Collections.emptyMap(), Collections.emptyList(), mock(APlusProject.class),
+        mock(CommonLibraryProvider.class));
 
     assertNull(course.getComponentIfExists(file1));
     assertNull(course.getComponentIfExists(file2));

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/MissingModuleNotificationTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/MissingModuleNotificationTest.java
@@ -1,0 +1,18 @@
+package fi.aalto.cs.apluscourses.intellij.notifications;
+
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MissingModuleNotificationTest {
+
+  @Test
+  public void testMissingModuleNotification() {
+    MissingModuleNotification notification = new MissingModuleNotification("module name");
+    Assert.assertEquals("Group ID should be A+", "A+", notification.getGroupId());
+    Assert.assertThat("The content should contain the module name", notification.getContent(),
+        containsString("module name"));
+  }
+
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -29,7 +29,7 @@ public class CourseTest {
     resourceUrls.put("key", new URL("http://localhost:8000"));
     List<String> autoInstallComponents = Arrays.asList(module1name);
     Course course = new Course("13", "Tester Course", modules, Collections.emptyList(),
-        requiredPlugins, resourceUrls, autoInstallComponents);
+        Collections.emptyMap(), requiredPlugins, resourceUrls, autoInstallComponents);
     assertEquals("The ID of the course should be the same as that given to the constructor",
         "13", course.getId());
     assertEquals("The name of the course should be the same as that given to the constructor",
@@ -54,7 +54,8 @@ public class CourseTest {
     Module module1 = new ModelExtensions.TestModule("Test Module");
     Module module2 = new ModelExtensions.TestModule("Awesome Module");
     Course course = new Course("", "", Arrays.asList(module1, module2), Collections.emptyList(),
-        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyList());
     assertSame("Course#getModule should return the correct module",
         module2, course.getComponent("Awesome Module"));
   }
@@ -67,7 +68,7 @@ public class CourseTest {
             moduleName, new URL("http://localhost:3000"), "random", null, null);
     Library library = new ModelExtensions.TestLibrary(libraryName);
     Course course = new Course("", "", Arrays.asList(module), Arrays.asList(library),
-            Collections.emptyMap(), Collections.emptyMap(),
+            Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
             Arrays.asList("test-module", "test-library"));
     List<Component> autoInstalls = course.getAutoInstallComponents();
     assertEquals("The course has the correct auto-install components", 2, autoInstalls.size());
@@ -79,7 +80,7 @@ public class CourseTest {
   public void testGetModuleWithMissingModule() throws NoSuchComponentException {
     Course course = new Course("Just some ID", "Just some course",
         Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(),
-        Collections.emptyMap(), Collections.emptyList());
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
     course.getComponent("Test Module");
   }
 
@@ -89,6 +90,7 @@ public class CourseTest {
       + "\"Scala\",\"org.test.tester\":\"Tester\"}";
   private static String modulesJson = "\"modules\":[{\"name\":\"O1Library\",\"url\":"
       + "\"https://wikipedia.org\"},{\"name\":\"GoodStuff\",\"url\":\"https://example.com\"}]";
+  private static String exerciseModulesJson = "\"exerciseModules\":{123:{\"en\":\"en_module\"}}";
   private static String resourcesJson = "\"resources\":{\"abc\":\"http://example.com\","
       + "\"def\":\"http://example.org\"}";
   private static String autoInstallJson = "\"autoInstall\":[\"O1Library\"]";
@@ -96,8 +98,8 @@ public class CourseTest {
   @Test
   public void testFromConfigurationFile() throws MalformedCourseConfigurationFileException {
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + ","
-        + requiredPluginsJson + "," + modulesJson + "," + resourcesJson + "," + autoInstallJson
-        + "}");
+        + requiredPluginsJson + "," + modulesJson + "," + exerciseModulesJson + "," + resourcesJson
+        + "," + autoInstallJson + "}");
     Course course = Course.fromConfigurationData(stringReader, "./path/to/file", MODEL_FACTORY);
     assertEquals("Course should have the same ID as that in the configuration JSON",
         "1238", course.getId());
@@ -111,6 +113,8 @@ public class CourseTest {
         "O1Library", course.getModules().get(0).getName());
     assertEquals("The course should have the modules of the configuration JSON",
         "GoodStuff", course.getModules().get(1).getName());
+    assertEquals("The course should have the exercise modules of the configuration JSON",
+        "en_module", course.getExerciseModules().get(123L).get("en"));
     assertEquals("The course should have the resource URLs of the configuration JSON",
         "http://example.com", course.getResourceUrls().get("abc").toString());
     assertEquals("The course should have the resource URLs of the configuration JSON",

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -186,11 +186,19 @@ public class ModelExtensions {
                                @NotNull String name,
                                @NotNull List<Module> modules,
                                @NotNull List<Library> libraries,
+                               @NotNull Map<Long, Map<String, String>> exerciseModules,
                                @NotNull Map<String, String> requiredPlugins,
                                @NotNull Map<String, URL> resourceUrls,
                                @NotNull List<String> autoInstallComponentNames) {
       return new Course(
-          id, name, modules, libraries, requiredPlugins, resourceUrls, autoInstallComponentNames
+          id,
+          name,
+          modules,
+          libraries,
+          exerciseModules,
+          requiredPlugins,
+          resourceUrls,
+          autoInstallComponentNames
       );
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 public class CourseProjectViewModelTest {
 
   private final Course emptyCourse = new Course("123", "NiceCourse", Collections.emptyList(),
-          Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
-          Collections.emptyList());
+      Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyList());
 
 
   @Test


### PR DESCRIPTION
# Description of the PR

The exercise submission action now uses the new exercise->module mapping from the course configuration file to determine from which module to submit instead of showing a module selection dialog to the user. The module selection dialog is still available as a fallback in case the mapping is missing an entry for some reason.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
