### PR TITLE
Fixed syntax highlight bug [#239]

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJLibrary.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJLibrary.java
@@ -34,7 +34,7 @@ public abstract class IntelliJLibrary
    */
   @CalledWithWriteLock
   @SuppressWarnings("unchecked")
-  public void loadInternal() {
+  protected void loadInternal() {
     LibraryTable.ModifiableModel libraryTable = project.getLibraryTable().getModifiableModel();
     com.intellij.openapi.roots.libraries.Library.ModifiableModel library = libraryTable
         .createLibrary(getName(), getLibraryKind())


### PR DESCRIPTION
# Description of the PR

Fixes #239 

The issue was that syntax highlighting didn't work if (for some reason) if `CLASSES` roots for libraries (see `.idea/libraries/scala_sdk_2_13_1.xml`  for some test project) used `file:` URL protocol instead of `jar:`. (_Interestingly_, Scala plugin uses `file:` protocol in `compiler-classpath`).

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
