### PR TITLE
Fixes bug where local changes could get overwritten even if user chos…

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
@@ -17,6 +17,7 @@ public abstract class Component {
   public static final int ERROR = StateMonitor.ERROR;
   public static final int UNRESOLVED = ERROR - 1;
   public static final int UNINSTALLED = UNRESOLVED - 1;
+  public static final int ACTION_ABORTED = 99;
 
   public static final int DEP_INITIAL = StateMonitor.INITIAL;
   public static final int DEP_WAITING = DEP_INITIAL + 1;
@@ -126,9 +127,12 @@ public abstract class Component {
         .allMatch(component -> component != null && component.stateMonitor.get() == LOADED);
   }
 
+  /**
+   * Sets component to the unresolved state, unless it is active.
+   */
   public void setUnresolved() {
-    // Only if not active
-    stateMonitor.setConditionallyTo(UNRESOLVED, NOT_INSTALLED, FETCHED, LOADED, ERROR, UNINSTALLED);
+    stateMonitor.setConditionallyTo(UNRESOLVED,
+        NOT_INSTALLED, FETCHED, LOADED, ERROR, UNINSTALLED, ACTION_ABORTED);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/module/ModuleListElementViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/module/ModuleListElementViewModel.java
@@ -49,6 +49,8 @@ public class ModuleListElementViewModel extends ListElementViewModel<Module> {
         return "Removing...";
       case Component.UNINSTALLED:
         return "Removed";
+      case Component.ACTION_ABORTED:
+        return "Cancelling...";
       default:
         return "Error";
     }


### PR DESCRIPTION
# Description of the PR

Fixes bug where local changes could get overwritten even if user chose "No" in the dialog when a module is updated.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
