### PR TITLE
Fix course project dialog

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -133,7 +133,7 @@ public class CourseProjectAction extends AnAction {
       return;
     }
 
-    startAutoInstallsWithRestart(course, courseProjectViewModel.userWantsRestart(), project);
+    startAutoInstallsWithRestart(course, !courseProjectViewModel.userOptsOutOfSettings(), project);
 
     if (!tryImportProjectSettings(project, course)) {
       return;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
@@ -2,7 +2,6 @@ package fi.aalto.cs.apluscourses.presentation;
 
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableProperty;
-import fi.aalto.cs.apluscourses.utils.observable.ObservableReadOnlyProperty;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableReadWriteProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
@@ -9,14 +9,12 @@ import org.jetbrains.annotations.Nullable;
 
 public class CourseProjectViewModel {
 
-  public final ObservableProperty<Boolean> restartProperty;
   public final ObservableProperty<Boolean> settingsOptOutProperty;
-  public final ObservableProperty<Boolean> isRestartAvailableProperty;
 
   @NotNull
   private final Course course;
   @Nullable
-  private final String currentlyImportedIdeSettings;
+
   private final boolean currentSettingsDiffer;
 
   /**
@@ -29,22 +27,10 @@ public class CourseProjectViewModel {
   public CourseProjectViewModel(@NotNull Course course,
                                 @Nullable String currentlyImportedIdeSettings) {
     this.course = course;
-    this.currentlyImportedIdeSettings = currentlyImportedIdeSettings;
+
     currentSettingsDiffer = !course.getId().equals(currentlyImportedIdeSettings);
 
-    restartProperty = new ObservableReadWriteProperty<>(currentSettingsDiffer);
-
     settingsOptOutProperty = new ObservableReadWriteProperty<>(!currentSettingsDiffer);
-
-    isRestartAvailableProperty = new ObservableReadOnlyProperty<>(this::isRestartAvailable);
-    isRestartAvailableProperty.declareDependentOn(settingsOptOutProperty);
-    isRestartAvailableProperty.addValueObserver(this, CourseProjectViewModel::onRestartEnabled);
-  }
-
-  private void onRestartEnabled(boolean restartEnabled) {
-    if (!restartEnabled) {
-      restartProperty.set(false);
-    }
   }
 
   public boolean shouldWarnUser() {
@@ -57,14 +43,6 @@ public class CourseProjectViewModel {
 
   public boolean canUserOptOutSettings() {
     return currentSettingsDiffer;
-  }
-
-  public boolean isRestartAvailable() {
-    return currentSettingsDiffer && !userOptsOutOfSettings();
-  }
-
-  public boolean userWantsRestart() {
-    return Boolean.TRUE.equals(restartProperty.get());
   }
 
   public boolean userOptsOutOfSettings() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectView">
-  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="13" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="658" height="400"/>
@@ -26,7 +26,7 @@
       </component>
       <component id="84cae" class="fi.aalto.cs.apluscourses.ui.base.CheckBox" binding="settingsOptOutCheckbox">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Leave IntelliJ settings unchanged."/>
@@ -34,7 +34,7 @@
       </component>
       <component id="5ef97" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -46,19 +46,19 @@
       </component>
       <vspacer id="eca37">
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>
       <vspacer id="c0273">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="79753" class="javax.swing.JLabel" binding="warningText">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="&lt;html&gt;(&lt;b&gt;Not recommended&lt;/b&gt;. Only pick this option if you are sure you know what you are doing.)&lt;/htm&gt;"/>
@@ -77,21 +77,6 @@
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="8"/>
-          </grid>
-        </constraints>
-      </vspacer>
-      <component id="b4256" class="fi.aalto.cs.apluscourses.ui.base.CheckBox" binding="restartCheckBox">
-        <constraints>
-          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Restart IntelliJ to reload settings."/>
-        </properties>
-      </component>
-      <vspacer id="20e32">
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-            <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
@@ -24,8 +24,6 @@ public class CourseProjectView extends DialogWrapper {
   @GuiObject
   private JLabel settingsInfoText;
   @GuiObject
-  private CheckBox restartCheckBox;
-  @GuiObject
   private CheckBox settingsOptOutCheckbox;
   @GuiObject
   private JLabel warningText;
@@ -40,9 +38,6 @@ public class CourseProjectView extends DialogWrapper {
     init();
 
     infoText.setIcon(Messages.getInformationIcon());
-
-    restartCheckBox.isCheckedBindable.bindToSource(viewModel.restartProperty);
-    restartCheckBox.isEnabledBindable.bindToSource(viewModel.isRestartAvailableProperty);
 
     settingsOptOutCheckbox.isCheckedBindable.bindToSource(viewModel.settingsOptOutProperty);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/PostponedRunnable.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/PostponedRunnable.java
@@ -1,12 +1,13 @@
 package fi.aalto.cs.apluscourses.utils;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import java.util.concurrent.Executor;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A runnable whose {@code run} method uses some {@code invokeLater} method (by default {@code
- * ApplicationManager.getApplication()::invokeLater} is used.
+ * ApplicationManager.getApplication()::invokeLater} with {@link ModalityState#NON_MODAL}is used).
  */
 public class PostponedRunnable implements Runnable {
   @NotNull
@@ -24,7 +25,8 @@ public class PostponedRunnable implements Runnable {
   }
 
   public PostponedRunnable(@NotNull Runnable task) {
-    this(task, ApplicationManager.getApplication()::invokeLater);
+    this(task, runnable ->
+        ApplicationManager.getApplication().invokeLater(runnable, ModalityState.NON_MODAL));
   }
 
   @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
@@ -48,7 +48,6 @@ public class CourseProjectActionTest extends BasePlatformTestCase {
     public boolean showMainDialog(@NotNull Project project,
                                   @NotNull CourseProjectViewModel courseProjectViewModel) {
       courseProjectViewModel.settingsOptOutProperty.set(doOptOut);
-      courseProjectViewModel.restartProperty.set(doRestart);
       return !doCancel;
     }
 
@@ -253,8 +252,10 @@ public class CourseProjectActionTest extends BasePlatformTestCase {
     Assert.assertEquals("The IDE is not restarted", 0, restarterCallCount.get());
   }
 
+
+
   @Test
-  public void testDoesNotRestartIfCheckboxUnselected() {
+  public void testDoesNotRestartIfSettingsOptOut() {
     createMockObjects();
     CourseProjectAction action = new CourseProjectAction(
         (url, proj) -> emptyCourse,
@@ -262,13 +263,11 @@ public class CourseProjectActionTest extends BasePlatformTestCase {
         settingsImporter,
         installerFactory,
         ideRestarter,
-        new TestDialogs(false, false, false),
+        new TestDialogs(false, false, true),
         installerDialogsFactory);
 
     action.actionPerformed(anActionEvent);
 
-    Assert.assertEquals("IDE settings are imported", 1,
-        settingsImporter.getImportIdeSettingsCallCount());
     Assert.assertEquals("The IDE is not restarted", 0, restarterCallCount.get());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -27,13 +27,9 @@ public class CourseProjectViewModelTest {
     CourseProjectViewModel courseProjectViewModel
         = new CourseProjectViewModel(emptyCourse, "different");
 
-    assertTrue("By default the user should want to restart",
-        courseProjectViewModel.userWantsRestart());
     assertFalse("By default the user should not want to opt out",
         courseProjectViewModel.userOptsOutOfSettings());
 
-    assertTrue("Restart should be available",
-        courseProjectViewModel.isRestartAvailable());
     assertTrue("Settings opt out should be available",
         courseProjectViewModel.canUserOptOutSettings());
 
@@ -46,11 +42,8 @@ public class CourseProjectViewModelTest {
     CourseProjectViewModel courseProjectViewModel
         = new CourseProjectViewModel(emptyCourse, "123");
 
-    assertFalse(courseProjectViewModel.userWantsRestart());
     assertTrue(courseProjectViewModel.userOptsOutOfSettings());
 
-    assertFalse("Restart should not be available",
-        courseProjectViewModel.isRestartAvailable());
     assertFalse("Settings opt out should not be available",
         courseProjectViewModel.canUserOptOutSettings());
 
@@ -58,20 +51,4 @@ public class CourseProjectViewModelTest {
         courseProjectViewModel.shouldShowCurrentSettings());
   }
 
-  @Test
-  public void testSettingsOptOutMakesRestartUnavailable() {
-    CourseProjectViewModel courseProjectViewModel = new CourseProjectViewModel(emptyCourse, "a");
-
-    courseProjectViewModel.settingsOptOutProperty.set(true);
-    assertFalse("Setting the settings opt out to true should make the restart option unavailable",
-        courseProjectViewModel.isRestartAvailable());
-    assertFalse("User should not want a restart after setting the opt out to true",
-        courseProjectViewModel.userWantsRestart());
-
-    courseProjectViewModel.settingsOptOutProperty.set(false);
-    assertTrue("Setting the settings opt out back to false should make the restart option available"
-        + " again", courseProjectViewModel.isRestartAvailable());
-    assertFalse("User should still not want a restart",
-        courseProjectViewModel.userWantsRestart());
-  }
 }


### PR DESCRIPTION
# Description of the PR

This PR removes the restart check box from the course project dialog. The restart check box is a potential source of confusion, since we actually only restart later when the auto-installs are completed, at which point a new restart dialog is shown anyways.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
