### PR TITLE
Make token field be in focus by default in the token dialog

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationView.java
@@ -61,4 +61,9 @@ public class APlusAuthenticationView extends DialogWrapper implements Dialog {
     return null;
   }
 
+  @Nullable
+  @Override
+  public JComponent getPreferredFocusedComponent() {
+    return inputField;
+  }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationViewTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationViewTest.java
@@ -10,6 +10,7 @@ import com.intellij.testFramework.LightIdeaTestCase;
 import fi.aalto.cs.apluscourses.model.APlusAuthentication;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.presentation.AuthenticationViewModel;
+import javax.swing.JPasswordField;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,10 +37,12 @@ public class APlusAuthenticationViewTest extends LightIdeaTestCase {
   public void testAplusAuthenticationView() {
     TestAuthenticationView authenticationView = new TestAuthenticationView();
 
-    Assert.assertEquals("The dialog has 'OK' and 'Cancel' buttons",
+    assertEquals("The dialog has 'OK' and 'Cancel' buttons",
         2, authenticationView.createActions().length);
     assertThat("The dialog title mentions 'A+ Token'", authenticationView.getTitle(),
         containsString("A+ Token"));
+    assertTrue("The password field is the preferred focused component",
+        authenticationView.getPreferredFocusedComponent() instanceof JPasswordField);
   }
 
   @Test


### PR DESCRIPTION
# Description of the PR

This fixes #247 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
