### PR TITLE
Course file bugfix

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -119,11 +119,6 @@ public class CourseProjectAction extends AnAction {
       return;
     }
 
-    // Note:
-    // IntelliJModelFactory uses CourseFileManager#getModulesMetadata, so this temporary course
-    // instance may contain some weird module metadata when switching between course projects (the
-    // local course file of the previous project remains loaded until another one is loaded).
-    // However, as this course instance is never displayed anywhere in the UI, it shouldn't matter.
     Course course = tryGetCourse(project, selectedCourseUrl);
     if (course == null) {
       return;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -229,7 +229,10 @@ public class CourseProjectAction extends AnAction {
                                       @NotNull String language) {
     try {
       if (createCourseFile) {
-        CourseFileManager.getInstance().createAndLoad(project, courseUrl, language);
+        PluginSettings
+            .getInstance()
+            .getCourseFileManager(project)
+            .createAndLoad(courseUrl, language);
       }
       return true;
     } catch (IOException e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -146,7 +146,10 @@ public class SubmitExerciseAction extends AnAction {
 
     Exercise exercise = selectedExercise.getModel();
     Course course = courseViewModel.getModel();
-    String language = CourseFileManager.getInstance().getLanguage();
+    String language = PluginSettings
+        .getInstance()
+        .getCourseFileManager(project)
+        .getLanguage();
     ExerciseDataSource exerciseDataSource = course.getExerciseDataSource();
 
     SubmissionInfo submissionInfo = exerciseDataSource.getSubmissionInfo(exercise, authentication);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -19,7 +19,6 @@ import fi.aalto.cs.apluscourses.intellij.notifications.SuccessfulSubmissionNotif
 import fi.aalto.cs.apluscourses.intellij.services.Dialogs;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.intellij.utils.VfsUtil;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -10,7 +10,6 @@ import fi.aalto.cs.apluscourses.intellij.notifications.CourseConfigurationError;
 import fi.aalto.cs.apluscourses.intellij.notifications.NetworkErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationFileException;
 import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -69,9 +69,12 @@ public class InitializationActivity implements Background {
     }
 
     try {
-      boolean isCourseProject = CourseFileManager.getInstance().load(project);
+      boolean isCourseProject = PluginSettings
+          .getInstance()
+          .getCourseFileManager(project)
+          .load();
       if (isCourseProject) {
-        return CourseFileManager.getInstance().getCourseUrl();
+        return PluginSettings.getInstance().getCourseFileManager(project).getCourseUrl();
       } else {
         return null;
       }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/APlusProject.java
@@ -25,9 +25,14 @@ public class APlusProject {
     this.project = project;
   }
 
+  /**
+   * Returns the IntelliJ IDEA project corresponding to this project. Throws {@link
+   * IllegalStateException} if the project is disposed.
+   * @return
+   */
   @CalledWithReadLock
   @NotNull
-  private Project getProject() {
+  public Project getProject() {
     if (project.isDisposed()) {
       throw new IllegalStateException("Project is disposed.");
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -2,7 +2,6 @@ package fi.aalto.cs.apluscourses.intellij.model;
 
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Component;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Library;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -1,6 +1,7 @@
 package fi.aalto.cs.apluscourses.intellij.model;
 
 import com.intellij.openapi.project.Project;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Component;
 import fi.aalto.cs.apluscourses.model.Course;
@@ -22,9 +23,15 @@ public class IntelliJModelFactory implements ModelFactory {
   private final Map<String, ModuleMetadata> modulesMetadata;
 
 
+  /**
+   * Construct a factory instance with the given project.
+   */
   public IntelliJModelFactory(@NotNull Project project) {
     this.project = new APlusProject(project);
-    modulesMetadata = CourseFileManager.getInstance().getModulesMetadata();
+    modulesMetadata = PluginSettings
+        .getInstance()
+        .getCourseFileManager(project)
+        .getModulesMetadata();
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.io.FileUtilRt;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.intellij.utils.ListDependenciesPolicy;
 import fi.aalto.cs.apluscourses.intellij.utils.VfsUtil;
 import fi.aalto.cs.apluscourses.model.ComponentLoadException;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
@@ -85,7 +85,10 @@ class IntelliJModule
   private void loadInternal() throws ComponentLoadException {
     try {
       project.getModuleManager().loadModule(getImlFile().toString());
-      CourseFileManager.getInstance().addEntryForModule(this);
+      PluginSettings
+          .getInstance()
+          .getCourseFileManager(project.getProject())
+          .addModuleEntry(this);
     } catch (Exception e) {
       throw new ComponentLoadException(getName(), e);
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import fi.aalto.cs.apluscourses.intellij.dal.IntelliJPasswordStorage;
+import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.presentation.MainViewModel;
 import fi.aalto.cs.apluscourses.presentation.MainViewModelUpdater;
 import java.util.Arrays;
@@ -64,9 +65,14 @@ public class PluginSettings implements MainViewModelProvider {
   private final ConcurrentMap<Project, MainViewModelUpdater> mainViewModelUpdaters
       = new ConcurrentHashMap<>();
 
+  @NotNull
+  private final ConcurrentMap<Project, CourseFileManager> courseFileManagers
+      = new ConcurrentHashMap<>();
+
   private final ProjectManagerListener projectManagerListener = new ProjectManagerListener() {
     @Override
     public void projectClosed(@NotNull Project project) {
+      courseFileManagers.remove(project);
       MainViewModelUpdater updater = mainViewModelUpdaters.remove(project);
       if (updater != null) {
         updater.interrupt();
@@ -134,6 +140,15 @@ public class PluginSettings implements MainViewModelProvider {
       mainViewModelUpdater.start();
       return mainViewModelUpdater;
     });
+  }
+
+  /**
+   * Returns the {@link CourseFileManager} instance corresponding to the given project. A new
+   * instance is created if no instance exists yet.
+   */
+  @NotNull
+  public CourseFileManager getCourseFileManager(@NotNull Project project) {
+    return courseFileManagers.computeIfAbsent(project, CourseFileManager::new);
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
@@ -25,12 +25,6 @@ public class CourseFileManager {
   private String language;
   private Map<String, ModuleMetadata> modulesMetadata;
 
-  private CourseFileManager() {
-
-  }
-
-  private static final CourseFileManager instance = new CourseFileManager();
-
   private static final String COURSE_FILE_NAME = "a-plus-project.json";
   private static final String URL_KEY = "url";
   private static final String LANGUAGE_KEY = "language";
@@ -38,8 +32,8 @@ public class CourseFileManager {
   private static final String MODULE_ID_KEY = "id";
   private static final String MODULE_DOWNLOADED_AT_KEY = "downloadedAt";
 
-  public static CourseFileManager getInstance() {
-    return instance;
+  public CourseFileManager(@NotNull Project project) {
+    courseFile = getCourseFile(project);
   }
 
   /**
@@ -47,21 +41,17 @@ public class CourseFileManager {
    * language. If a course file for already exists, then the URL and language is overwritten, but
    * the existing modules metadata in the course file is preserved.
    *
-   * @param project   The project for which the course file is created.
    * @param courseUrl The URL that gets added to the course file.
    * @param language  The language string that gets added to the course file.
    * @throws IOException If an IO error occurs.
    */
-  public synchronized void createAndLoad(@NotNull Project project,
-                                         @NotNull URL courseUrl,
-                                         @NotNull String language)
-      throws IOException {
-    courseFile = getCourseFile(project);
-
+  public synchronized void createAndLoad(@NotNull URL courseUrl,
+                                         @NotNull String language) throws IOException {
     if (courseFile.exists()) {
-      load(project);
+      load();
     } else {
       // createAndLoad never overwrites modules metadata of an existing course file.
+      // Should this be in the constructor?
       this.modulesMetadata = new HashMap<>();
     }
     this.courseUrl = courseUrl;
@@ -78,14 +68,12 @@ public class CourseFileManager {
    * Attempts to load the course file corresponding to the given project. Returns {@code false} if
    * the course file doesn't exist, {@code true} otherwise.
    *
-   * @param project The project from which the course file is loaded.
    * @return {@code true} if the course file was successfully loaded, {@code false} if the course
    *         file doesn't exist.
    * @throws IOException   If an IO error occurs while reading the course file.
    * @throws JSONException If the course file contains malformed JSON.
    */
-  public synchronized boolean load(@NotNull Project project) throws IOException {
-    courseFile = getCourseFile(project);
+  public synchronized boolean load() throws IOException {
     if (courseFile.exists()) {
       JSONObject jsonObject = readCourseFile();
       loadFromJsonObject(jsonObject);
@@ -94,8 +82,6 @@ public class CourseFileManager {
     return false;
   }
 
-
-
   /**
    * Adds an entry for the given module to the currently loaded course file. If an entry already
    * exists for the given module, then it is overwritten with the new entry.
@@ -103,7 +89,7 @@ public class CourseFileManager {
    * @param module The module for which an entry is added.
    * @throws IOException If an IO error occurs while writing to the course file.
    */
-  public synchronized void addEntryForModule(@NotNull Module module) throws IOException {
+  public synchronized void addModuleEntry(@NotNull Module module) throws IOException {
     ModuleMetadata newModuleMetadata = module.getMetadata();
     JSONObject newModuleObject = new JSONObject()
         .put(MODULE_ID_KEY, newModuleMetadata.getModuleId())
@@ -152,16 +138,6 @@ public class CourseFileManager {
   public synchronized Map<String, ModuleMetadata> getModulesMetadata() {
     // Return a copy so that later changes to the map aren't visible in the returned map.
     return modulesMetadata != null ? new HashMap<>(modulesMetadata) : Collections.emptyMap();
-  }
-
-  /**
-   * Clears the URL, language, and modules metadata stored in the singleton instance. The course
-   * file itself is not modified.
-   */
-  public synchronized void clear() {
-    this.courseUrl = null;
-    this.language = null;
-    this.modulesMetadata = null;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
@@ -57,14 +57,15 @@ public class CourseFileManager {
                                          @NotNull String language)
       throws IOException {
     courseFile = getCourseFile(project);
+
     if (courseFile.exists()) {
       load(project);
+    } else {
+      // createAndLoad never overwrites modules metadata of an existing course file.
+      this.modulesMetadata = new HashMap<>();
     }
     this.courseUrl = courseUrl;
     this.language = language;
-    if (this.modulesMetadata == null) {
-      this.modulesMetadata = new HashMap<>(); // Don't overwrite existing modules metadata
-    }
     writeCourseFile(
         new JSONObject()
             .put(URL_KEY, courseUrl.toString())

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
@@ -9,6 +9,7 @@ import fi.aalto.cs.apluscourses.dal.TokenAuthentication;
 import fi.aalto.cs.apluscourses.intellij.model.IntelliJModelFactory;
 import fi.aalto.cs.apluscourses.intellij.notifications.NewModulesVersionsNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Component;
 import fi.aalto.cs.apluscourses.model.Course;
@@ -64,7 +65,10 @@ public class MainViewModelUpdater {
       if (project.isDisposed() || !project.isOpen()) {
         return null;
       }
-      return CourseFileManager.getInstance().getCourseUrl();
+      return PluginSettings
+          .getInstance()
+          .getCourseFileManager(project)
+          .getCourseUrl();
     });
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
@@ -10,7 +10,6 @@ import fi.aalto.cs.apluscourses.intellij.model.IntelliJModelFactory;
 import fi.aalto.cs.apluscourses.intellij.notifications.NewModulesVersionsNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Component;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Module;

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -31,6 +31,7 @@ import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.SuccessfulSubmissionNotification;
 import fi.aalto.cs.apluscourses.intellij.services.Dialogs;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;
@@ -163,9 +164,11 @@ public class SubmitExerciseActionTest {
 
     project = mock(Project.class);
     doReturn(FileUtilRt.getTempDirectory()).when(project).getBasePath();
-    CourseFileManager.getInstance().createAndLoad(
-        project, new URL("http://localhost:8000"), language);
-    assertEquals(language, CourseFileManager.getInstance().getLanguage());
+
+    PluginSettings
+        .getInstance()
+        .getCourseFileManager(project)
+        .createAndLoad(new URL("http://localhost:8000"), language);
 
     filePath = modulePath.resolve(fileName);
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -32,7 +32,6 @@ import fi.aalto.cs.apluscourses.intellij.notifications.SuccessfulSubmissionNotif
 import fi.aalto.cs.apluscourses.intellij.services.Dialogs;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
-import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Exercise;

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
@@ -40,7 +40,6 @@ public class CourseFileManagerTest {
   private static final String MODULE_DOWNLOADED_AT_KEY = "downloadedAt";
 
   private CourseFileManager manager;
-  private Project project;
   private File courseFile;
   private List<Thread> threads;
   private AtomicBoolean threadFailed;
@@ -65,7 +64,7 @@ public class CourseFileManagerTest {
    */
   @Before
   public void initializeObjects() throws IOException {
-    project = mock(Project.class);
+    Project project = mock(Project.class);
     File tempDir = FileUtilRt.createTempDirectory("test", "", true);
     doReturn(tempDir.toString()).when(project).getBasePath();
     FileUtilRt.createTempDirectory(tempDir, Project.DIRECTORY_STORE_FOLDER, "", true);


### PR DESCRIPTION
# Description of the PR

This fixes the bug discovered by Nikolai, where creating a new project from another project carries over the modules metadata form the previous project into the new project.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
