### PR TITLE
Local history submission tagging

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
+import static icons.PluginIcons.ACCENT_COLOR;
 
 import com.intellij.history.LocalHistory;
 import com.intellij.notification.Notifications;
@@ -84,7 +85,7 @@ public class SubmitExerciseAction extends AnAction {
         DefaultModuleSource.INSTANCE,
         Dialogs.DEFAULT,
         Notifications.Bus::notify,
-        LocalHistory.getInstance()::putUserLabel
+        LocalHistory.getInstance()::putSystemLabel
     );
   }
 
@@ -147,7 +148,7 @@ public class SubmitExerciseAction extends AnAction {
     }
 
     ExerciseViewModel selectedExercise = exercisesViewModel.getSelectedExercise();
-    ExerciseGroupViewModel selectedExerciseGroup = exercisesViewModel.getSelectedExerciseGroup();
+    ExerciseGroupViewModel selectedExerciseGroup = exercisesViewModel.getGroupOfSelectedExercise();
     if (selectedExercise == null || selectedExerciseGroup == null) {
       notifier.notify(new ExerciseNotSelectedNotification(), project);
       return;
@@ -218,19 +219,19 @@ public class SubmitExerciseAction extends AnAction {
     ).start();
     notifier.notify(new SubmissionSentNotification(), project);
 
-    String tag = getAndReplaceText("ui.toolWindow.subTab.exercises.submission.tag",
+    String tag = getAndReplaceText("ui.localHistory.submission.tag",
         selectedExerciseGroup.getPresentableName(),
         submission.getPresentableExerciseName(),
         submission.getCurrentSubmissionNumber());
-    dropLocalHistoryTag(project, tag);
+    addLocalHistoryTag(project, tag);
   }
 
   private void notifyNetworkError(@NotNull IOException exception, @Nullable Project project) {
     notifier.notify(new NetworkErrorNotification(exception), project);
   }
 
-  private void dropLocalHistoryTag(@NotNull Project project, @NotNull String tag) {
-    tagger.putUserLabel(project, tag);
+  private void addLocalHistoryTag(@NotNull Project project, @NotNull String tag) {
+    tagger.putSystemLabel(project, tag, ACCENT_COLOR);
   }
 
   public interface ModuleSource {
@@ -276,6 +277,6 @@ public class SubmitExerciseAction extends AnAction {
 
   @FunctionalInterface
   public interface Tagger {
-    void putUserLabel(@Nullable Project project, @NotNull String tag);
+    void putSystemLabel(@Nullable Project project, @NotNull String tag, int color);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -71,6 +71,9 @@ public class SubmitExerciseAction extends AnAction {
   @NotNull
   private final Notifier notifier;
 
+  @NotNull
+  private final Tagger tagger;
+
   /**
    * Constructor with reasonable defaults.
    */
@@ -80,7 +83,8 @@ public class SubmitExerciseAction extends AnAction {
         VfsUtil::findFileInDirectory,
         DefaultModuleSource.INSTANCE,
         Dialogs.DEFAULT,
-        Notifications.Bus::notify
+        Notifications.Bus::notify,
+        LocalHistory.getInstance()::putUserLabel
     );
   }
 
@@ -92,12 +96,14 @@ public class SubmitExerciseAction extends AnAction {
                               @NotNull FileFinder fileFinder,
                               @NotNull ModuleSource moduleSource,
                               @NotNull Dialogs dialogs,
-                              @NotNull Notifier notifier) {
+                              @NotNull Notifier notifier,
+                              @NotNull Tagger tagger) {
     this.mainViewModelProvider = mainViewModelProvider;
     this.fileFinder = fileFinder;
     this.moduleSource = moduleSource;
     this.dialogs = dialogs;
     this.notifier = notifier;
+    this.tagger = tagger;
   }
 
   @Override
@@ -224,7 +230,7 @@ public class SubmitExerciseAction extends AnAction {
   }
 
   private void dropLocalHistoryTag(@NotNull Project project, @NotNull String tag) {
-    LocalHistory.getInstance().putUserLabel(project, tag);
+    tagger.putUserLabel(project, tag);
   }
 
   public interface ModuleSource {
@@ -266,5 +272,10 @@ public class SubmitExerciseAction extends AnAction {
     public String getModuleName() {
       return moduleName;
     }
+  }
+
+  @FunctionalInterface
+  public interface Tagger {
+    void putUserLabel(@Nullable Project project, @NotNull String tag);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -1,7 +1,9 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.history.LocalHistory;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -34,6 +36,7 @@ import fi.aalto.cs.apluscourses.model.SubmittableFile;
 import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
 import fi.aalto.cs.apluscourses.presentation.MainViewModel;
 import fi.aalto.cs.apluscourses.presentation.ModuleSelectionViewModel;
+import fi.aalto.cs.apluscourses.presentation.exercise.ExerciseGroupViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExerciseViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionViewModel;
@@ -138,7 +141,8 @@ public class SubmitExerciseAction extends AnAction {
     }
 
     ExerciseViewModel selectedExercise = exercisesViewModel.getSelectedExercise();
-    if (selectedExercise == null) {
+    ExerciseGroupViewModel selectedExerciseGroup = exercisesViewModel.getSelectedExerciseGroup();
+    if (selectedExercise == null || selectedExerciseGroup == null) {
       notifier.notify(new ExerciseNotSelectedNotification(), project);
       return;
     }
@@ -207,10 +211,20 @@ public class SubmitExerciseAction extends AnAction {
         exerciseDataSource, authentication, submissionUrl, selectedExercise.getPresentableName()
     ).start();
     notifier.notify(new SubmissionSentNotification(), project);
+
+    String tag = getAndReplaceText("ui.toolWindow.subTab.exercises.submission.tag",
+        selectedExerciseGroup.getPresentableName(),
+        submission.getPresentableExerciseName(),
+        submission.getCurrentSubmissionNumber());
+    dropLocalHistoryTag(project, tag);
   }
 
   private void notifyNetworkError(@NotNull IOException exception, @Nullable Project project) {
     notifier.notify(new NetworkErrorNotification(exception), project);
+  }
+
+  private void dropLocalHistoryTag(@NotNull Project project, @NotNull String tag) {
+    LocalHistory.getInstance().putUserLabel(project, tag);
   }
 
   public interface ModuleSource {

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExercisesTreeViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExercisesTreeViewModel.java
@@ -30,7 +30,8 @@ public class ExercisesTreeViewModel extends BaseViewModel<List<ExerciseGroup>>
    */
   @Nullable
   public ExerciseViewModel getSelectedExercise() {
-    return getGroupViewModels().stream()
+    return getGroupViewModels()
+        .stream()
         .flatMap(group -> group.getExerciseViewModels().stream())
         .filter(ExerciseViewModel::isSelected)
         .findFirst()
@@ -42,12 +43,29 @@ public class ExercisesTreeViewModel extends BaseViewModel<List<ExerciseGroup>>
    */
   @Nullable
   public SubmissionResultViewModel getSelectedSubmission() {
-    return getGroupViewModels().stream()
+    return getGroupViewModels()
+        .stream()
         .flatMap(group -> group.getExerciseViewModels().stream())
         .flatMap(exercise -> exercise.getSubmissionResultViewModels().stream())
         .filter(SubmissionResultViewModel::isSelected)
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * Returns the exercise group where the selected exercise belongs, or null if no exercise is
+   * selected.
+   */
+  @Nullable
+  public ExerciseGroupViewModel getSelectedExerciseGroup() {
+    for (ExerciseGroupViewModel exerciseGroupViewModel : getGroupViewModels()) {
+      for (ExerciseViewModel exerciseViewModel : exerciseGroupViewModel.getExerciseViewModels()) {
+        if (exerciseViewModel.isSelected()) {
+          return exerciseGroupViewModel;
+        }
+      }
+    }
+    return null;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExercisesTreeViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExercisesTreeViewModel.java
@@ -57,7 +57,7 @@ public class ExercisesTreeViewModel extends BaseViewModel<List<ExerciseGroup>>
    * selected.
    */
   @Nullable
-  public ExerciseGroupViewModel getSelectedExerciseGroup() {
+  public ExerciseGroupViewModel getGroupOfSelectedExercise() {
     for (ExerciseGroupViewModel exerciseGroupViewModel : getGroupViewModels()) {
       for (ExerciseViewModel exerciseViewModel : exerciseGroupViewModel.getExerciseViewModels()) {
         if (exerciseViewModel.isSelected()) {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;

--- a/src/main/java/icons/PluginIcons.java
+++ b/src/main/java/icons/PluginIcons.java
@@ -6,7 +6,7 @@ import javax.swing.Icon;
 /**
  * Guide: https://www.jetbrains.org/intellij/sdk/docs/reference_guide/work_with_icons_and_images.html
  * Icons source: https://jetbrains.design/intellij/resources/icons_list/
- * Accent colour: #FF0090(FF) (100% opacity)
+ * Accent colour: #FF0090(FF) (100% opacity) aka RGB(255, 0, 144)
  * Light schema: #AFB1B3(FF) (100% opacity)
  * Dark schema: #6E6E6E(FF) (100% opacity)
  */

--- a/src/main/java/icons/PluginIcons.java
+++ b/src/main/java/icons/PluginIcons.java
@@ -1,16 +1,22 @@
 package icons;
 
 import com.intellij.openapi.util.IconLoader;
+import com.intellij.ui.JBColor;
+import java.awt.Color;
 import javax.swing.Icon;
 
 /**
  * Guide: https://www.jetbrains.org/intellij/sdk/docs/reference_guide/work_with_icons_and_images.html
- * Icons source: https://jetbrains.design/intellij/resources/icons_list/
- * Accent colour: #FF0090(FF) (100% opacity) aka RGB(255, 0, 144)
- * Light schema: #AFB1B3(FF) (100% opacity)
- * Dark schema: #6E6E6E(FF) (100% opacity)
+ * Icons source: https://jetbrains.design/intellij/resources/icons_list/ Accent colour: #FF0090(FF)
+ * (100% opacity) aka RGB(255, 0, 144) Light schema: #AFB1B3(FF) (100% opacity) Dark schema:
+ * #6E6E6E(FF) (100% opacity)
  */
 public interface PluginIcons {
+
+  int ACCENT_COLOR = new JBColor(
+      new Color(255, 0, 144),
+      new Color(255, 0, 144)
+  ).getRGB();
 
   Icon A_PLUS_MODULE = IconLoader.getIcon("/META-INF/icons/module.svg");
   Icon A_PLUS_EXERCISE_GROUP = IconLoader.getIcon("/META-INF/icons/exerciseGroup.svg");

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -88,6 +88,7 @@ ui.toolWindow.subTab.exercises.submission.submitExercise=Submit Assignment
 ui.toolWindow.subTab.exercises.submission.selectModule=Please select which module you wish to submit:
 ui.toolWindow.subTab.exercises.submission.selectModuleShort=Select Module
 ui.toolWindow.subTab.exercises.submission.selectAModule=Select a module
+ui.toolWindow.subTab.exercises.submission.tag={0}, {1}, Submission {2}
 
 ## CourseProject
 ui.courseProject.dialogs.showRestartDialog.title=Restart IntelliJ

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -88,7 +88,6 @@ ui.toolWindow.subTab.exercises.submission.submitExercise=Submit Assignment
 ui.toolWindow.subTab.exercises.submission.selectModule=Please select which module you wish to submit:
 ui.toolWindow.subTab.exercises.submission.selectModuleShort=Select Module
 ui.toolWindow.subTab.exercises.submission.selectAModule=Select a module
-ui.toolWindow.subTab.exercises.submission.tag={0}, {1}, Submission {2}
 
 ## CourseProject
 ui.courseProject.dialogs.showRestartDialog.title=Restart IntelliJ
@@ -117,3 +116,4 @@ ui.authenticationView.tokenLink=What is my token?
 ui.aboutDialog.description=<html>The A+ Courses plugin supports the educational use of IntelliJ (and its Scala plugin) in<br>programming courses that rely on the A+ learning management system, which has been<br>developed at Aalto University. The plugin accesses programming assignments<br>and automated grading services provided by A+ and otherwise enhances<br>the student experience.</html>
 ui.aboutDialog.title=About the A+ Courses Plugin
 ui.aboutDialog.website=A+ Courses Plugin website
+ui.localHistory.submission.tag={0}, {1}, Submission {2}

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -232,6 +234,7 @@ public class SubmitExerciseActionTest {
         ArgumentCaptor.forClass(SubmissionSentNotification.class);
 
     verify(notifier).notify(notificationArg.capture(), eq(project));
+    verify(tagger).putSystemLabel(any(), anyString(), anyInt());
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtilRt;
 import fi.aalto.cs.apluscourses.intellij.DialogHelper;
+import fi.aalto.cs.apluscourses.intellij.actions.SubmitExerciseAction.Tagger;
 import fi.aalto.cs.apluscourses.intellij.notifications.ExerciseNotSelectedNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.MissingFileNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.MissingModuleNotification;
@@ -102,11 +103,12 @@ public class SubmitExerciseActionTest {
   AnActionEvent event;
   SubmitExerciseAction action;
   Points points;
+  Tagger tagger;
 
   /**
    * Called before each test.
    *
-   * @throws IOException Never.
+   * @throws IOException               Never.
    * @throws FileDoesNotExistException Never.
    */
   @SuppressWarnings("unchecked")
@@ -180,7 +182,7 @@ public class SubmitExerciseActionTest {
     doCallRealMethod().when(fileFinder).findFiles(any(), any());
 
     moduleSource = mock(SubmitExerciseAction.ModuleSource.class);
-    doReturn(new Module[] { module }).when(moduleSource).getModules(project);
+    doReturn(new Module[]{module}).when(moduleSource).getModules(project);
     doReturn(module).when(moduleSource).getModule(project, moduleName);
 
     dialogs = new Dialogs();
@@ -205,7 +207,10 @@ public class SubmitExerciseActionTest {
     submissionDialogFactory = new DialogHelper.Factory<>(submissionDialog, project);
     dialogs.register(SubmissionViewModel.class, submissionDialogFactory);
 
-    action = new SubmitExerciseAction(mainVmProvider, fileFinder, moduleSource, dialogs, notifier);
+    tagger = mock(Tagger.class);
+
+    action = new SubmitExerciseAction(mainVmProvider, fileFinder, moduleSource, dialogs, notifier,
+        tagger);
   }
 
   @Test


### PR DESCRIPTION
# Description of the PR

I know this is ridiculous... but some time after the daily I was looking for a way to solve my current task (#272), when I bumped into a way to drop a tag in local history. I could not resist and decided to try - it was tempting and promised quick results.

And now, suddenly I find myself writing a PR text for a task that was not meant to ~~ever~~ be done. Please, forgive me this moment of weakness and review the PR.

+ drops a tag in `LocalHistory` like "Week, Assignment, Submission"
![Screenshot from 2020-08-24 19-46-00](https://user-images.githubusercontent.com/9991098/91073110-35523a00-e643-11ea-9dd5-b166db053dbf.png)
+ tag is project-level (project state is being tagger)
+ if/when testing, keep in mind, that you need to actually change the file, otherwise you'd be getting **only** the latest tag
+ could make the tag "pink" as well, but  unsure if the approach would be appropriate (asked [here](https://jetbrains-platform.slack.com/archives/C5U8BM1MK/p1598290214066300))


# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [x] Not yet. I will do it next (if the feature is approved)
- [ ] Not relevant
