### PR TITLE
Show points of individual submissions

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -29,12 +29,13 @@ public class Exercise {
   /**
    * Construct an exercise instance with the given parameters.
    *
-   * @param id                 The ID of the exercise.
-   * @param name               The name of the exercise.
-   * @param submissionResults  A list of submission results corresponding to this exercise.
-   * @param userPoints         The best points that the user has gotten from this exercise.
-   * @param maxPoints          The maximum points available from this exercise.
-   * @param maxSubmissions     The maximum number of submissions allowed for this exercise.
+   * @param id                The ID of the exercise.
+   * @param name              The name of the exercise.
+   * @param htmlUrl           A URL to the HTML page of the exercise.
+   * @param submissionResults A list of submission results corresponding to this exercise.
+   * @param userPoints        The best points that the user has gotten from this exercise.
+   * @param maxPoints         The maximum points available from this exercise.
+   * @param maxSubmissions    The maximum number of submissions allowed for this exercise.
    */
   public Exercise(long id,
                   @NotNull String name,

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -68,7 +68,7 @@ public class Exercise {
     String name = jsonObject.getString("display_name");
     String htmlUrl = jsonObject.getString("html_url");
 
-    int userPoints = points.getPoints().getOrDefault(id, 0);
+    int userPoints = points.getExercisePoints().getOrDefault(id, 0);
     int maxPoints = jsonObject.getInt("max_points");
     int maxSubmissions = jsonObject.getInt("max_submissions");
 
@@ -76,10 +76,12 @@ public class Exercise {
     List<SubmissionResult> submissionResults = IntStream
         .range(0, submissionIds.size())
         .mapToObj(i -> {
+          long submissionId = submissionIds.get(i);
+          int submissionPoints = points.getSubmissionPoints().getOrDefault(submissionId, 0);
           SubmissionResult.Status status = (i + 1 > maxSubmissions)
               ? SubmissionResult.Status.UNOFFICIAL
               : SubmissionResult.Status.GRADED;
-          return new SubmissionResult(submissionIds.get(i), status, htmlUrl);
+          return new SubmissionResult(submissionId, submissionPoints, htmlUrl, status);
         })
         .collect(Collectors.toList());
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Points.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Points.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionResult.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionResult.java
@@ -13,6 +13,8 @@ public class SubmissionResult {
 
   private final long submissionId;
 
+  private final int points;
+
   @NotNull
   private final Status status;
 
@@ -22,8 +24,12 @@ public class SubmissionResult {
   /**
    * Construct an instance with the given ID and exercise URL.
    */
-  public SubmissionResult(long submissionId, @NotNull Status status, @NotNull String exerciseUrl) {
+  public SubmissionResult(long submissionId,
+                          int points,
+                          @NotNull String exerciseUrl,
+                          @NotNull Status status) {
     this.submissionId = submissionId;
+    this.points = points;
     this.status = status;
     this.exerciseUrl = exerciseUrl;
   }
@@ -36,7 +42,7 @@ public class SubmissionResult {
   @NotNull
   public static SubmissionResult fromJsonObject(@NotNull JSONObject jsonObject) {
     long id = jsonObject.getLong("id");
-
+    int points = jsonObject.getInt("grade");
     String exerciseUrl = jsonObject.getJSONObject("exercise").getString("html_url");
 
     Status status = Status.UNKNOWN;
@@ -47,11 +53,15 @@ public class SubmissionResult {
       status = Status.UNOFFICIAL;
     }
 
-    return new SubmissionResult(id, status, exerciseUrl);
+    return new SubmissionResult(id, points, exerciseUrl, status);
   }
 
   public long getId() {
     return submissionId;
+  }
+
+  public int getPoints() {
+    return points;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -24,7 +24,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
     List<SubmissionResult> submissionResults = exercise.getSubmissionResults();
     this.submissionResultViewModels = IntStream
         .range(0, submissionResults.size())
-        .mapToObj(i -> new SubmissionResultViewModel(submissionResults.get(i), i + 1))
+        .mapToObj(i -> new SubmissionResultViewModel(this, submissionResults.get(i), i + 1))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModel.java
@@ -12,20 +12,29 @@ import org.jetbrains.annotations.Nullable;
 public class SubmissionResultViewModel extends SelectableNodeViewModel<SubmissionResult>
     implements TreeViewModel {
 
+  private final ExerciseViewModel parent;
+
   private final int submissionNumber;
 
   /**
    * Construct a view model corresponding to the given submission result.
    */
-  public SubmissionResultViewModel(@NotNull SubmissionResult submissionResult,
+  public SubmissionResultViewModel(@NotNull ExerciseViewModel parent,
+                                   @NotNull SubmissionResult submissionResult,
                                    int submissionNumber) {
     super(submissionResult);
+    this.parent = parent;
     this.submissionNumber = submissionNumber;
   }
 
   @NotNull
   public String getPresentableName() {
     return getText("presentation.submissionResultViewModel.nameStart") + " " + submissionNumber;
+  }
+
+  @NotNull
+  public String getStatusText() {
+    return getModel().getPoints() + "/" + parent.getModel().getMaxPoints() + " points";
   }
 
   @Nullable

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
@@ -32,6 +32,9 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
     }
   }
 
+  private static final SimpleTextAttributes STATUS_TEXT_STYLE = new SimpleTextAttributes(
+      SimpleTextAttributes.STYLE_ITALIC | SimpleTextAttributes.STYLE_SMALLER, null);
+
   @Override
   public void customizeCellRenderer(@NotNull JTree tree,
                                     Object value,
@@ -50,8 +53,7 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
     if (userObject instanceof ExerciseViewModel) {
       ExerciseViewModel exerciseViewModel = (ExerciseViewModel) userObject;
       append(exerciseViewModel.getPresentableName());
-      append(" [" + exerciseViewModel.getStatusText() + "]", new SimpleTextAttributes(
-              SimpleTextAttributes.STYLE_ITALIC | SimpleTextAttributes.STYLE_SMALLER, null));
+      append(" [" + exerciseViewModel.getStatusText() + "]", STATUS_TEXT_STYLE);
       setEnabled(exerciseViewModel.isSubmittable());
       setToolTipText(exerciseViewModel.isSubmittable()
           ? "Use the upload button to submit an exercise"
@@ -68,6 +70,7 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
       SubmissionResultViewModel submissionResultViewModel = (SubmissionResultViewModel) userObject;
       setEnabled(true);
       append(submissionResultViewModel.getPresentableName());
+      append(" [" + submissionResultViewModel.getStatusText() + "]", STATUS_TEXT_STYLE);
       setToolTipText("Double-click the submission to open it in the browser");
     }
   }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
@@ -17,6 +17,7 @@ import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.model.UrlRenderer;
 import fi.aalto.cs.apluscourses.presentation.MainViewModel;
+import fi.aalto.cs.apluscourses.presentation.exercise.ExerciseViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionResultViewModel;
 import org.junit.Before;
@@ -38,7 +39,8 @@ public class OpenSubmissionActionTest {
   public void setUp() {
     submissionResult
         = new SubmissionResult(1, 0, "http://example.com", SubmissionResult.Status.GRADED);
-    SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 1);
+    SubmissionResultViewModel viewModel
+        = new SubmissionResultViewModel(mock(ExerciseViewModel.class), submissionResult, 1);
 
     ExercisesTreeViewModel exercisesTree = mock(ExercisesTreeViewModel.class);
     doReturn(viewModel).when(exercisesTree).getSelectedSubmission();

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
@@ -37,7 +37,7 @@ public class OpenSubmissionActionTest {
   @Before
   public void setUp() {
     submissionResult
-        = new SubmissionResult(1, SubmissionResult.Status.GRADED, "http://example.com");
+        = new SubmissionResult(1, 0, "http://example.com", SubmissionResult.Status.GRADED);
     SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 1);
 
     ExercisesTreeViewModel exercisesTree = mock(ExercisesTreeViewModel.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
@@ -36,7 +36,7 @@ public class OpenSubmissionNotificationActionTest {
     event = mock(AnActionEvent.class);
     doReturn(mock(Project.class)).when(event).getProject();
     submissionResult
-        = new SubmissionResult(1, SubmissionResult.Status.GRADED, "http://example.com");
+        = new SubmissionResult(1, 0, "http://example.com", SubmissionResult.Status.GRADED);
     notification = mock(Notification.class);
     notifier = mock(Notifier.class);
     submissionRenderer = mock(UrlRenderer.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -130,7 +130,7 @@ public class SubmitExerciseActionTest {
     mainViewModel = new MainViewModel();
 
     authentication = mock(Authentication.class);
-    points = new Points(Collections.emptyMap(), Collections.emptyMap());
+    points = new Points(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
 
     exerciseDataSource = mock(ExerciseDataSource.class);
     course = spy(new ModelExtensions.TestCourse("91", "NineOne Course", exerciseDataSource));

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
@@ -15,7 +15,7 @@ public class FeedbackAvailableNotificationTest {
   @Test
   public void testFeedbackAvailableNotificationTest() {
     SubmissionResult result
-        = new SubmissionResult(0, SubmissionResult.Status.GRADED, "https://example.com");
+        = new SubmissionResult(0, 0, "https://example.com", SubmissionResult.Status.GRADED);
     Notification notification = new FeedbackAvailableNotification(result, "Test Exercise");
 
     assertEquals("Group ID should be A+", "A+", notification.getGroupId());

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -5,6 +5,10 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -35,10 +39,14 @@ public class ExerciseTest {
   @NotNull
   @Contract(" -> new")
   private static Points createTestPoints() {
-    return new Points(
-        Collections.singletonMap(11L, Arrays.asList(1L, 2L)),
-        Collections.singletonMap(11L, 10)
-    );
+    long exerciseId = 11L;
+    List<Long> submissionIds = Arrays.asList(1L, 2L);
+    Map<Long, List<Long>> submissions = Collections.singletonMap(exerciseId, submissionIds);
+    Map<Long, Integer> exercisePoints = Collections.singletonMap(exerciseId, 10);
+    Map<Long, Integer> submissionPoints = new HashMap<>();
+    submissionPoints.put(1L, 33);
+    submissionPoints.put(2L, 44);
+    return new Points(submissions, exercisePoints, submissionPoints);
   }
 
   private static final Points TEST_POINTS = createTestPoints();
@@ -70,6 +78,10 @@ public class ExerciseTest {
         1L, exercise.getSubmissionResults().get(0).getId());
     assertEquals("The submission IDs are read from the points object",
         2L, exercise.getSubmissionResults().get(1).getId());
+    assertEquals("The submission points are read from the points object",
+        33, exercise.getSubmissionResults().get(0).getPoints());
+    assertEquals("The submission points are read from the points object",
+        44, exercise.getSubmissionResults().get(1).getPoints());
     assertEquals("The user points are read from the points object",
         10, exercise.getUserPoints());
     assertEquals("The max points is the same as the one in the JSON object",

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -60,7 +60,7 @@ public class ModelExtensions {
     @Override
     public Points getPoints(@NotNull Course course, @NotNull Authentication authentication)
         throws IOException {
-      return new Points(Collections.emptyMap(), Collections.emptyMap());
+      return new Points(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
     }
 
     @NotNull
@@ -68,7 +68,7 @@ public class ModelExtensions {
     public SubmissionResult getSubmissionResult(@NotNull String submissionUrl,
                                                 @NotNull Authentication authentication)
         throws IOException {
-      return new SubmissionResult(0, SubmissionResult.Status.GRADED, "http://localhost:8000");
+      return new SubmissionResult(0, 20,"http://localhost:8000", SubmissionResult.Status.GRADED);
     }
 
     @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/model/PointsTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/PointsTest.java
@@ -2,9 +2,11 @@ package fi.aalto.cs.apluscourses.model;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,9 +15,13 @@ public class PointsTest {
 
   @Test
   public void testPoints() {
+    Map<Long, Integer> submissionPoints = new HashMap<>();
+    submissionPoints.put(11L, 44);
+    submissionPoints.put(22L, 55);
     Points points = new Points(
         Collections.singletonMap(123L, Arrays.asList(11L, 22L)),
-        Collections.singletonMap(123L, 55)
+        Collections.singletonMap(123L, 55),
+        submissionPoints
     );
 
     Assert.assertEquals("The submission ID list is the same as that given to the constructor",
@@ -23,65 +29,60 @@ public class PointsTest {
     Assert.assertEquals("The submission ID list is the same as that given to the constructor",
         Long.valueOf(22L), points.getSubmissions().get(123L).get(1));
     Assert.assertEquals("The points for an exercise is the same as that given to the constructor",
-        Integer.valueOf(55), points.getPoints().get(123L));
+        Integer.valueOf(55), points.getExercisePoints().get(123L));
+    Assert.assertEquals("The submission points are the same as those given to the constructor",
+        Integer.valueOf(44), points.getSubmissionPoints().get(11L));
+    Assert.assertEquals("The submission points are the same as those given to the constructor",
+        Integer.valueOf(55), points.getSubmissionPoints().get(22L));
   }
 
   @Test
   public void testFromJsonObject() {
-    String jsonObjectString = getLargeJsonString();
-    JSONObject jsonObject = new JSONObject(jsonObjectString);
+    JSONArray submissionsWithPoints1 = new JSONArray()
+        .put(new JSONObject().put("id", 1L).put("grade", 10))
+        .put(new JSONObject().put("id", 2L).put("grade", 20));
+    JSONArray submissionsWithPoints2 = new JSONArray()
+        .put(new JSONObject().put("id", 3L).put("grade", 30))
+        .put(new JSONObject().put("id", 4L).put("grade", 40));
 
-    Points points = Points.fromJsonObject(jsonObject);
-    Map<Long, Integer> idToPoints = points.getPoints();
+    JSONArray exercises = new JSONArray()
+        .put(new JSONObject()
+            .put("id", 100L)
+            .put("points", 20)
+            .put("submissions_with_points", submissionsWithPoints1))
+        .put(new JSONObject()
+            .put("id", 200L)
+            .put("points", 40)
+            .put("submissions_with_points", submissionsWithPoints2));
 
-    int[] exercisePoints = new int[] {
-        idToPoints.get(26038L),
-        idToPoints.get(26039L),
-        idToPoints.get(26160L),
-        idToPoints.get(26162L)
-    };
+    JSONArray modules = new JSONArray()
+        .put(new JSONObject().put("exercises", exercises));
 
-    Assert.assertArrayEquals("The points of exercises are the same as those in the JSON",
-        new int[] {5, 2, 0, 0}, exercisePoints);
+    JSONObject json = new JSONObject().put("modules", modules);
 
-    Assert.assertEquals("The submissions for exercises are the same as those in the JSON reversed",
-        Long.valueOf(2921874L), points.getSubmissions().get(26038L).get(2));
-    Assert.assertEquals("The submissions for exercises are the same as those in the JSON reversed",
-        Long.valueOf(2921867L), points.getSubmissions().get(26038L).get(1));
-  }
+    Points points = Points.fromJsonObject(json);
 
-  @NotNull
-  @Contract(pure = true)
-  private String getLargeJsonString() {
-    return "{\"id\":19457,\"url\":\"https://plus.cs.aalto.fi/api/v2/users/19457/?format=json\","
-        + "\"username\":\"testik34@aalto.fi\",\"student_id\":\"TESTI64\","
-        + "\"email\":\"19457@localhost\",\"full_name\":\"KuusikymmentÃ¤neljÃ¤TESTI-Opiskelija\","
-        + "\"is_external\":false,\"tags\":[],\"submission_count\":3,"
-        + "\"points\":5,\"points_by_difficulty\":{\"A\":5},"
-        + "\"modules\":[{\"exercises\":[{\"passed\":true,\"official\":true,\"difficulty\":\"A\","
-        + "\"name\":\"|fi:TehtÃ¤vÃ¤1(Piazza)|en:Assignment1(Piazza)|\","
-        + "\"submissions\":[\"https://plus.cs.aalto.fi/api/v2/submissions/2921874/?format=json\","
-        + "\"https://plus.cs.aalto.fi/api/v2/submissions/2921867/?format=json\","
-        + "\"https://plus.cs.aalto.fi/api/v2/submissions/2921858/?format=json\"],"
-        + "\"submission_count\":3,\"points_to_pass\":0,\"id\":26038,\"points\":5,"
-        + "\"best_submission\":\"https://plus.cs.aalto.fi/api/v2/submissions/2921874/?format=json\","
-        + "\"url\":\"https://plus.cs.aalto.fi/api/v2/exercises/26038/?format=json\","
-        + "\"max_points\":5},{\"passed\":true,\"official\":true,\"difficulty\":\"\","
-        + "\"name\":\"|fi:Palaute|en:Feedback|\","
-        + "\"submissions\":[\"https://plus.cs.aalto.fi/api/v2/submissions/2921872/?format=json\"],"
-        + "\"submission_count\":1,\"points_to_pass\":1,\"id\":26039,\"points\":2,"
-        + "\"best_submission\":\"https://plus.cs.aalto.fi/api/v2/submissions/2921872/?format=json\","
-        + "\"url\":\"https://plus.cs.aalto.fi/api/v2/exercises/26039/?format=json\","
-        + "\"max_points\":2}]},{\"exercises\":[{\"passed\":false,\"official\":false,"
-        + "\"difficulty\":\"\",\"name\":\"|fi:Palaute|en:Feedback|\",\"submissions\":[],"
-        + "\"submission_count\":0,\"points_to_pass\":1,\"id\":26160,\"points\":0,"
-        + "\"best_submission\":null,"
-        + "\"url\":\"https://plus.cs.aalto.fi/api/v2/exercises/26160/?format=json\","
-        + "\"max_points\":2},{\"passed\":true,\"official\":false,\"difficulty\":\"A\","
-        + "\"name\":\"|fi:TehtÃ¤vÃ¤1(FlappyBug5)|en:Assignment1(FlappyBug5)|\",\"submissions\":[],"
-        + "\"submission_count\":0,\"points_to_pass\":0,\"id\":26162,\"points\":0,"
-        + "\"best_submission\":null,"
-        + "\"url\":\"https://plus.cs.aalto.fi/api/v2/exercises/26162/?format=json\","
-        + "\"max_points\":10}]}]}";
+    Assert.assertEquals("The exercise points are parsed from the JSON",
+        Integer.valueOf(20), points.getExercisePoints().get(100L));
+    Assert.assertEquals("The exercise points are parsed from the JSON",
+        Integer.valueOf(40), points.getExercisePoints().get(200L));
+
+    Assert.assertEquals("The submission IDs are parsed from the JSON (in reverse order)",
+        Long.valueOf(2L), points.getSubmissions().get(100L).get(0));
+    Assert.assertEquals("The submission IDs are parsed from the JSON (in reverse order)",
+        Long.valueOf(1L), points.getSubmissions().get(100L).get(1));
+    Assert.assertEquals("The submission IDs are parsed from the JSON (in reverse order)",
+        Long.valueOf(4L), points.getSubmissions().get(200L).get(0));
+    Assert.assertEquals("The submission IDs are parsed from the JSON (in reverse order)",
+        Long.valueOf(3L), points.getSubmissions().get(200L).get(1));
+
+    Assert.assertEquals("The submission points are parsed from the JSON",
+        Integer.valueOf(10), points.getSubmissionPoints().get(1L));
+    Assert.assertEquals("The submission points are parsed from the JSON",
+        Integer.valueOf(20), points.getSubmissionPoints().get(2L));
+    Assert.assertEquals("The submission points are parsed from the JSON",
+        Integer.valueOf(30), points.getSubmissionPoints().get(3L));
+    Assert.assertEquals("The submission points are parsed from the JSON",
+        Integer.valueOf(40), points.getSubmissionPoints().get(4L));
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/PointsTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/PointsTest.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
@@ -10,9 +10,11 @@ public class SubmissionResultTest {
   @Test
   public void testSubmissionResult() {
     SubmissionResult submissionResult
-        = new SubmissionResult(123L, SubmissionResult.Status.GRADED, "http://example.com/");
+        = new SubmissionResult(123L, 13, "http://example.com/", SubmissionResult.Status.GRADED);
     assertEquals("The ID is the same as the one given to the constructor",
         123L, submissionResult.getId());
+    assertEquals("The grade is the same as the one given to the constructor",
+        13, submissionResult.getPoints());
     assertEquals("The status is the samme as the one given to the constructor",
         SubmissionResult.Status.GRADED, submissionResult.getStatus());
     assertEquals("The submission URL is correct", "http://example.com/submissions/123/",
@@ -23,6 +25,7 @@ public class SubmissionResultTest {
   public void testFromJsonObject() {
     JSONObject jsonObject = new JSONObject()
         .put("id", 234)
+        .put("grade", 30)
         .put("exercise", new JSONObject()
             .put("html_url", "https://example.com/"))
         .put("status", "ready");
@@ -30,6 +33,8 @@ public class SubmissionResultTest {
 
     assertEquals("The ID is the same as the one in the JSON object",
         234L, submissionResult.getId());
+    assertEquals("The grade is the same as the one in the JSON object",
+        30, submissionResult.getPoints());
     assertEquals("The status is parsed correctly from the JSON object",
         SubmissionResult.Status.GRADED, submissionResult.getStatus());
     assertEquals("The exercise URL is taken correctly from the JSON object",

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -35,16 +35,17 @@ public class SubmissionStatusUpdaterTest {
 
       if (submissionResultFetchCount.incrementAndGet() >= limit) {
         return new SubmissionResult(
-          123L,
-          SubmissionResult.Status.GRADED,
-          "https://example.org"
+            123L,
+            0,
+            "https://example.org",
+            SubmissionResult.Status.GRADED
         );
       } else {
         return new SubmissionResult(
             123L,
-            SubmissionResult.Status.UNKNOWN,
-            "https://example.com/"
-
+            0,
+            "https://example.com/",
+            SubmissionResult.Status.UNKNOWN
         );
       }
     }

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
@@ -61,14 +61,14 @@ public class ExerciseViewModelTest {
     String htmlUrl = "http://localhost:6000";
     SubmissionResult.Status resultStatus = SubmissionResult.Status.GRADED;
     Exercise training = new Exercise(0, "", htmlUrl,
-        Collections.singletonList(new SubmissionResult(1L, resultStatus, htmlUrl)), 0, 0, 0);
+        Collections.singletonList(new SubmissionResult(1L, 0, htmlUrl, resultStatus)), 0, 0, 0);
     Exercise noSubmissions = new Exercise(0, "", htmlUrl, Collections.emptyList(), 0, 10, 10);
     Exercise noPoints = new Exercise(0, "", htmlUrl,
-        Collections.singletonList(new SubmissionResult(1L, resultStatus, htmlUrl)), 0, 10, 10);
+        Collections.singletonList(new SubmissionResult(1L, 0, htmlUrl, resultStatus)), 0, 10, 10);
     Exercise partialPoints = new Exercise(0, "", htmlUrl,
-        Collections.singletonList(new SubmissionResult(1L, resultStatus, htmlUrl)), 5, 10, 10);
+        Collections.singletonList(new SubmissionResult(1L, 5, htmlUrl, resultStatus)), 5, 10, 10);
     Exercise fullPoints = new Exercise(0, "", htmlUrl,
-        Collections.singletonList(new SubmissionResult(1L, resultStatus, htmlUrl)), 10, 10, 10);
+        Collections.singletonList(new SubmissionResult(1L, 10, htmlUrl, resultStatus)), 10, 10, 10);
 
     Assert.assertEquals(ExerciseViewModel.Status.OPTIONAL_PRACTICE,
         new ExerciseViewModel(training).getStatus());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
@@ -9,7 +9,7 @@ public class SubmissionResultViewModelTest {
   @Test
   public void testSubmissionResultViewModel() {
     SubmissionResult submissionResult
-        = new SubmissionResult(123L, SubmissionResult.Status.UNKNOWN, "https://example.com/");
+        = new SubmissionResult(123L, 15,"https://example.com/", SubmissionResult.Status.UNKNOWN);
     SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 34);
 
     Assert.assertEquals("Submission 34", viewModel.getPresentableName());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
@@ -1,6 +1,8 @@
 package fi.aalto.cs.apluscourses.presentation.exercise;
 
+import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
+import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -8,11 +10,17 @@ public class SubmissionResultViewModelTest {
 
   @Test
   public void testSubmissionResultViewModel() {
+
     SubmissionResult submissionResult
         = new SubmissionResult(123L, 15,"https://example.com/", SubmissionResult.Status.UNKNOWN);
-    SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 34);
+    ExerciseViewModel exerciseViewModel = new ExerciseViewModel(
+        new Exercise(0, "", "", Collections.singletonList(submissionResult),
+            15, 25, 10));
+    SubmissionResultViewModel viewModel
+        = new SubmissionResultViewModel(exerciseViewModel, submissionResult, 34);
 
     Assert.assertEquals("Submission 34", viewModel.getPresentableName());
+    Assert.assertEquals("15/25 points", viewModel.getStatusText());
     Assert.assertNull(viewModel.getSubtrees());
   }
 


### PR DESCRIPTION
# Description of the PR

This resolves #302 using the new `submissions_with_points` addition to the A+ API.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
