### PR TITLE
Don't show submission limit warning for optional practice assignments

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -203,7 +203,7 @@ public class SubmitExerciseAction extends AnAction {
     SubmissionHistory history = exerciseDataSource.getSubmissionHistory(exercise, authentication);
 
     List<Group> groups = new ArrayList<>(exerciseDataSource.getGroups(course, authentication));
-    groups.add(0, new Group(0, Collections
+    groups.add(0, new Group(-1, Collections
         .singletonList(getText("ui.toolWindow.subTab.exercises.submission.submitAlone"))));
 
     SubmissionViewModel submission =

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -76,6 +76,10 @@ public class SubmissionViewModel {
     return submittableFiles;
   }
 
+  public int getCurrentSubmissionNumber() {
+    return submissionHistory.getNumberOfSubmissions() + 1;
+  }
+
   /**
    * Returns a string describing which submission the user is about to make and what the submission
    * limit is (if it exists).
@@ -83,7 +87,7 @@ public class SubmissionViewModel {
   @NotNull
   public String getSubmissionCountText() {
     StringBuilder submissionCountText = new StringBuilder("You are about to make submission ");
-    submissionCountText.append(submissionHistory.getNumberOfSubmissions() + 1);
+    submissionCountText.append(getCurrentSubmissionNumber());
     if (submissionInfo.getSubmissionsLimit() != 0) {
       submissionCountText.append(" out of ");
       submissionCountText.append(submissionInfo.getSubmissionsLimit());

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -76,12 +76,20 @@ public class SubmissionViewModel {
     return submittableFiles;
   }
 
-  public int getCurrentSubmissionNumber() {
-    return submissionHistory.getNumberOfSubmissions() + 1;
-  }
-
-  public int getMaxNumberOfSubmissions() {
-    return submissionInfo.getSubmissionsLimit();
+  /**
+   * Returns a string describing which submission the user is about to make and what the submission
+   * limit is (if it exists).
+   */
+  @NotNull
+  public String getSubmissionCountText() {
+    StringBuilder submissionCountText = new StringBuilder("You are about to make submission ");
+    submissionCountText.append(submissionHistory.getNumberOfSubmissions() + 1);
+    if (submissionInfo.getSubmissionsLimit() != 0) {
+      submissionCountText.append(" out of ");
+      submissionCountText.append(submissionInfo.getSubmissionsLimit());
+    }
+    submissionCountText.append('.');
+    return submissionCountText.toString();
   }
 
   /**
@@ -91,6 +99,9 @@ public class SubmissionViewModel {
    */
   @Nullable
   public String getSubmissionWarning() {
+    if (submissionInfo.getSubmissionsLimit() == 0) {
+      return null;
+    }
     int submissionsLeft =
         submissionInfo.getSubmissionsLimit() - submissionHistory.getNumberOfSubmissions();
     if (submissionsLeft == 1) {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
@@ -53,7 +53,7 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
     if (userObject instanceof ExerciseViewModel) {
       ExerciseViewModel exerciseViewModel = (ExerciseViewModel) userObject;
       append(exerciseViewModel.getPresentableName());
-      if (!exerciseViewModel.getStatusText().isBlank()) {
+      if (!exerciseViewModel.getStatusText().trim().isEmpty()) {
         append(" [" + exerciseViewModel.getStatusText() + "]", STATUS_TEXT_STYLE);
       }
       setEnabled(exerciseViewModel.isSubmittable());

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
@@ -81,12 +81,7 @@ public class SubmissionDialog extends OurDialogWrapper {
     filenamesHtml.append("</ul></body></html>");
     filenames = new JLabel(filenamesHtml.toString());
 
-    submissionCount = new JLabel(String.format("You are about to make submission %d out of %d.",
-        viewModel.getCurrentSubmissionNumber(), viewModel.getMaxNumberOfSubmissions()));
+    submissionCount = new JLabel(viewModel.getSubmissionCountText());
   }
 
-  @FunctionalInterface
-  public interface Factory {
-    SubmissionDialog createDialog(@NotNull SubmissionViewModel viewModel);
-  }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
@@ -265,7 +265,7 @@ public class CoursesClient {
             new ByteArrayInputStream(EntityUtils.toByteArray(entity))
         ));
         details = json.optString("detail");
-        if (details == null || details.isBlank()) {
+        if (details == null || details.trim().isEmpty()) {
           details = String.join(", ", json
               .getJSONArray("errors")
               .toList()

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -63,6 +63,7 @@ public class SubmissionViewModelTest {
     SubmissionViewModel submissionViewModel1 = new SubmissionViewModel(exercise, info,
         new SubmissionHistory(3), Collections.emptyList(), Collections.emptyMap(), "");
 
+    assertEquals(4, submissionViewModel1.getCurrentSubmissionNumber());
     assertEquals("You are about to make submission 4 out of 5.",
         submissionViewModel1.getSubmissionCountText());
     assertNull(submissionViewModel1.getSubmissionWarning());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -57,25 +57,38 @@ public class SubmissionViewModelTest {
   @Test
   public void testSubmissionNumbers() {
     Exercise exercise = new Exercise(1, "ex", "http://localhost:2000", Collections.emptyList(),
-        0, 0, 0);
+        0, 0, 5);
     SubmissionInfo info = new SubmissionInfo(5, Collections.emptyMap());
 
     SubmissionViewModel submissionViewModel1 = new SubmissionViewModel(exercise, info,
         new SubmissionHistory(3), Collections.emptyList(), Collections.emptyMap(), "");
 
-    assertEquals(5, submissionViewModel1.getMaxNumberOfSubmissions());
-    assertEquals(4, submissionViewModel1.getCurrentSubmissionNumber());
+    assertEquals("You are about to make submission 4 out of 5.",
+        submissionViewModel1.getSubmissionCountText());
     assertNull(submissionViewModel1.getSubmissionWarning());
 
     SubmissionViewModel submissionViewModel2 = new SubmissionViewModel(exercise, info,
         new SubmissionHistory(4), Collections.emptyList(), Collections.emptyMap(), "");
 
+    assertEquals("You are about to make submission 5 out of 5.",
+        submissionViewModel2.getSubmissionCountText());
     assertNotNull(submissionViewModel2.getSubmissionWarning());
 
     SubmissionViewModel submissionViewModel3 = new SubmissionViewModel(exercise, info,
         new SubmissionHistory(5), Collections.emptyList(), Collections.emptyMap(), "");
 
+    assertEquals("You are about to make submission 6 out of 5.",
+        submissionViewModel3.getSubmissionCountText());
     assertNotNull(submissionViewModel3.getSubmissionWarning());
+
+    // Max submissions 0
+    SubmissionInfo practiceAssignment = new SubmissionInfo(0, Collections.emptyMap());
+    SubmissionViewModel submissionViewModel4 = new SubmissionViewModel(exercise, practiceAssignment,
+        new SubmissionHistory(2), Collections.emptyList(), Collections.emptyMap(), "");
+
+    assertEquals("You are about to make submission 3.",
+        submissionViewModel4.getSubmissionCountText());
+    assertNull(submissionViewModel4.getSubmissionWarning());
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
@@ -52,8 +52,9 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
     doReturn(exerciseName).when(viewModel).getPresentableExerciseName();
     doReturn(availableGroups).when(viewModel).getAvailableGroups();
     doReturn(files).when(viewModel).getFiles();
-    doReturn(numberOfSubmissions).when(viewModel).getCurrentSubmissionNumber();
-    doReturn(maxNumberOfSubmissions).when(viewModel).getMaxNumberOfSubmissions();
+    doReturn("You are about to make submission 4 out of 10.")
+        .when(viewModel)
+        .getSubmissionCountText();
     return viewModel;
   }
 


### PR DESCRIPTION
# Description of the PR

Fixes #345 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
