### PR TITLE
NPE is thrown if the default module (O1Module) is missing

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -112,17 +112,18 @@ class ReplAction extends RunConsoleAction {
 
   }
 
-  def getDefaultModule(@NotNull project: Project): Option[Module] =
-    Option(ModuleManager.getInstance(project).findModuleByName(PluginSettings
-      .getInstance()
-      .getMainViewModel(project)
-      .courseViewModel
-      .get()
-      .getModel
-      .getAutoInstallComponentNames
-      //  we, hereby, commonly agree, that the first in the list auto install component (module)
-      //  is ultimately REPL's default module (as it's most likely to exist). sorry :pensive:
-      .head))
+  def getDefaultModule(@NotNull project: Project): Option[Module] = {
+    Option(PluginSettings.getInstance().getMainViewModel(project).courseViewModel.get) match {
+      case Some(courseViewModel) =>
+        Option(ModuleManager.getInstance(project).findModuleByName(courseViewModel
+          .getModel
+          .getAutoInstallComponentNames
+          //  we, hereby, commonly agree, that the first in the list auto install component (module)
+          //  is ultimately REPL's default module (as it's most likely to exist). sorry :pensive:
+          .head))
+      case None => None
+    }
+  }
 
   def setConfigurationFields(@NotNull configuration: ScalaConsoleRunConfiguration,
                              @NotNull workingDirectory: String,

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -72,7 +72,9 @@ class ReplAction extends RunConsoleAction {
         if (!setConfigurationConditionally(project, module, configuration)) {
           return // scalastyle:ignore
         }
-      case None => // For now, no dialog is shown for a project level REPL
+      case None =>
+        super.actionPerformed(e) // Delegate to the original Scala Plugin REPL
+        return // scalastyle:ignore
     }
     RunConsoleAction.runExisting(setting, runManagerEx, project)
   }


### PR DESCRIPTION
Description of the PR

+ the NPE is gone now
+ all REPLs are now O1 REPLs look-and-feel, so great!

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
