### PR TITLE
Create updating main view model only after auto-installs have completed

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -172,14 +172,10 @@ public class CourseProjectAction extends AnAction {
     Future<Boolean> ideSettingsImported =
         executor.submit(() -> importIdeSettings && tryImportIdeSettings(project, course));
 
-    if (createCourseFile) {
-      // The course file not created in testing.
-      PluginSettings.getInstance().createUpdatingMainViewModel(project);
-    }
-
     executor.execute(() -> {
       try {
         autoInstallDone.get();
+        PluginSettings.getInstance().createUpdatingMainViewModel(project);
         if (projectSettingsImported.get() && importIdeSettings && ideSettingsImported.get()) {
           ideRestarter.run();
         }


### PR DESCRIPTION
# Description of the PR

This should finally completely fix the race condition between auto-installs and updates, which occasionally leads to `O1Library` being shown as not installed.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
