### PR TITLE
Fix REPL null pointer exception

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
@@ -27,15 +27,15 @@ object ModuleUtils {
     FileUtilRt.toSystemIndependentName(ModuleUtilCore.getModuleDirPath(module))
 
   def getModuleOfEditorFile(@NotNull project: Project,
-                            @NotNull dataContext: DataContext): Option[Module] = for {
-    editor <- Option(CommonDataKeys.EDITOR.getData(dataContext))
-    openFile <- Option(FileDocumentManager.getInstance.getFile(editor.getDocument))
-  } yield ModuleUtilCore.findModuleForFile(openFile, project)
+                            @NotNull dataContext: DataContext): Option[Module] =
+    Option(CommonDataKeys.EDITOR.getData(dataContext))
+        .flatMap(editor => Option(FileDocumentManager.getInstance.getFile(editor.getDocument)))
+        .flatMap(openFile => Option(ModuleUtilCore.findModuleForFile(openFile, project)))
 
   def getModuleOfSelectedFile(@NotNull project: Project,
                               @NotNull dataContext: DataContext): Option[Module] =
     Option(CommonDataKeys.VIRTUAL_FILE.getData(dataContext))
-      .map(file => ModuleUtilCore.findModuleForFile(file, project))
+      .flatMap(file => Option(ModuleUtilCore.findModuleForFile(file, project)))
 
   def nonEmpty(enumerator: OrderEnumerator): Boolean = {
     var nonEmpty = false


### PR DESCRIPTION
# Description of the PR

The issue is caused by the fact, that `getModuleOfEditorFile` could actually return `Some(null)` in certain situations due to an oversight of mine. This leads to a situation where `Some(null).filter(hasScalaSdk)` is evaluated, which causes an error since `hasScalaSdk` has a `@NotNull` annotation on its module parameter. This PR fixes both `getModuleOfEditorFile` and `getModuleOfSelectedFile` to always either return `None` or `Some(module)`, but never `Some(null)`.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
