### PR TITLE
Fix sorting of assignments (use HTML URL instead of ID)

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
@@ -1,12 +1,13 @@
 package fi.aalto.cs.apluscourses.presentation.exercise;
 
-import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.ExerciseGroup;
 import fi.aalto.cs.apluscourses.presentation.base.SelectableNodeViewModel;
 import fi.aalto.cs.apluscourses.presentation.base.TreeViewModel;
 import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,8 +27,8 @@ public class ExerciseGroupViewModel extends SelectableNodeViewModel<ExerciseGrou
         .getExercises()
         .values()
         .stream()
-        .sorted(Comparator.comparingLong(Exercise::getId))
         .map(ExerciseViewModel::new)
+        .sorted(EXERCISE_COMPARATOR) // O1_SPECIFIC
         .collect(Collectors.toList());
   }
 
@@ -44,5 +45,62 @@ public class ExerciseGroupViewModel extends SelectableNodeViewModel<ExerciseGrou
   @Override
   public List<ExerciseViewModel> getSubtrees() {
     return getExerciseViewModels();
+  }
+
+  // O1_SPECIFIC
+  private static final Comparator<ExerciseViewModel> EXERCISE_COMPARATOR = (exercise1, exercise2)
+      -> {
+    int chapter1 = getExerciseChapter(exercise1);
+    int chapter2 = getExerciseChapter(exercise2);
+    if (chapter1 > chapter2) {
+      return 1;
+    }
+    if (chapter2 > chapter1) {
+      return -1;
+    }
+
+    // Feedback exercises are always last
+    if ("Feedback".equals(exercise1.getPresentableName())) {
+      return 1;
+    }
+    if ("Feedback".equals(exercise2.getPresentableName())) {
+      return -1;
+    }
+
+    int number1 = getExerciseNumber(exercise1);
+    int number2 = getExerciseNumber(exercise2);
+    if (number1 > number2) {
+      return 1;
+    }
+    if (number2 > number1) {
+      return -1;
+    }
+    return 0;
+  };
+
+  private static final Pattern CHAPTER_REGEX = Pattern.compile("\\/w[0-9]+\\/ch([0-9]+)\\/");
+
+  private static int getExerciseChapter(@NotNull ExerciseViewModel exercise) {
+    String htmlUrl = exercise.getModel().getHtmlUrl();
+    Matcher matcher = CHAPTER_REGEX.matcher(htmlUrl);
+    matcher.find();
+    try {
+      return Integer.parseInt(matcher.group(1));
+    } catch (IllegalStateException | NumberFormatException | IndexOutOfBoundsException e) {
+      return -1;
+    }
+  }
+
+  private static final Pattern NUMBER_REGEX = Pattern.compile("w[0-9]+_ch[0-9]+_([0-9]+)");
+
+  private static int getExerciseNumber(@NotNull ExerciseViewModel exercise) {
+    String htmlUrl = exercise.getModel().getHtmlUrl();
+    Matcher matcher = NUMBER_REGEX.matcher(htmlUrl);
+    matcher.find();
+    try {
+      return Integer.parseInt(matcher.group(1));
+    } catch (IllegalStateException | NumberFormatException | IndexOutOfBoundsException e) {
+      return -1;
+    }
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
@@ -26,22 +26,29 @@ public class ExerciseGroupViewModelTest {
 
   @Test
   public void testSortsExercises() {
-    Exercise first = new Exercise(1, "Assignment 0", "http://localhost:1000",
+    Exercise first = new Exercise(424, "Assignment 3",
+        "http://localhost:1000/w10/ch02/w10_ch02_03/", Collections.emptyList(), 0, 0,0);
+    Exercise second = new Exercise(325, "Feedback",
+        "http://localhost:2000/w10/ch02/w10_ch02_feedback/", Collections.emptyList(), 0, 0,0);
+    Exercise third = new Exercise(195, "Assignment 1", "http://localhost:3000/w10/ch03/w10_ch03_01/",
         Collections.emptyList(), 0, 0,0);
-    Exercise second = new Exercise(2, "Assignment 5", "http://localhost:2000",
-        Collections.emptyList(), 0, 0,0);
-    Exercise third = new Exercise(3, "Assignment 10", "http://localhost:3000",
-        Collections.emptyList(), 0, 0,0);
+    Exercise fourth = new Exercise(908, "Feedback",
+        "http://localhost:3000/w10/ch03/w10_ch03_feedback/", Collections.emptyList(), 0, 0, 0);
+    Exercise fifth = new Exercise(282, "Assignment 1",
+        "http://localhost:3000/w10/ch04/w10_ch04_01/", Collections.emptyList(), 0, 0, 0);
 
-    ExerciseGroup group = new ExerciseGroup("", Arrays.asList(third, second, first));
+    ExerciseGroup group = new ExerciseGroup("", Arrays.asList(third, fifth, first, fourth, second));
     ExerciseGroupViewModel groupViewModel = new ExerciseGroupViewModel(group);
-    List<ExerciseViewModel> exerciseViewModels = groupViewModel.getExerciseViewModels();
 
-    String message = "The exercises are sorted by IDs";
+    Long[] ids = groupViewModel
+        .getExerciseViewModels()
+        .stream()
+        .map(ExerciseViewModel::getModel)
+        .map(Exercise::getId)
+        .toArray(Long[]::new);
 
-    Assert.assertEquals(message, first.getName(), exerciseViewModels.get(0).getPresentableName());
-    Assert.assertEquals(message, second.getName(), exerciseViewModels.get(1).getPresentableName());
-    Assert.assertEquals(message, third.getName(), exerciseViewModels.get(2).getPresentableName());
+    Assert.assertArrayEquals("The exercises are sorted correctly",
+        new Long[] {424L, 325L, 195L, 908L, 282L}, ids);
   }
 
 }


### PR DESCRIPTION
# Description of the PR

The logic for comparing two exercises is as follows:
  1. Parse the chapters out of the HTML URLs. If either one has a higher chapter number, then that exercise comes later.
  2. If the chapter numbers are equal, check if either of the exercises is a feedback exercise. Feedback exercises always come later than other exercises in the same chapter.
  3. If neither exercise is a feedback exercise, parse the exercise numbers out of the HTML URLs and compare those.
  4. If any of the steps above fail (which happens for an example for supplementary page assignments), consider the exercises equal.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
