### PR TITLE
Course file fix

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Module.java
@@ -71,10 +71,7 @@ public abstract class Module extends Component {
       throws MalformedURLException {
     String name = jsonObject.getString("name");
     URL url = new URL(jsonObject.getString("url"));
-    String versionId = jsonObject.optString("id");
-    if (versionId == null) {
-      versionId = "";
-    }
+    String versionId = jsonObject.optString("id", "");
     return factory.createModule(name, url, versionId);
   }
 

--- a/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionHeavyTest.scala
+++ b/src/test/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplActionHeavyTest.scala
@@ -15,7 +15,9 @@ class ReplActionHeavyTest extends HeavyPlatformTestCase with TestHelperScala {
     //  given
     val configuration = getConfiguration
     val module = mock(classOf[Module])
-    when(module.getProject).thenReturn(mock(classOf[Project]))
+    val project = mock(classOf[Project])
+    when(project.isDefault).thenReturn(true)
+    when(module.getProject).thenReturn(project)
     when(module.getModuleFilePath).thenReturn("directory/module.iml")
     when(module.getName).thenReturn("mock module")
 
@@ -37,7 +39,4 @@ class ReplActionHeavyTest extends HeavyPlatformTestCase with TestHelperScala {
 
   private def getConfiguration = super.getConfiguration(getProject)
 
-  private def getModuleManager = super.getModuleManager(getProject)
-
-  private def createAndAddModule(path: String, id: String): Unit = super.createAndAddModule(getProject, path, id)
 }


### PR DESCRIPTION
# Description of the PR

This PR uses the project path as the key of a map instead of the project itself. It also prevents a missing `downloadedAt` or `language` in the course file from causing an uncaught exception.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
