### PR TITLE
Specified user-agent header of http requests

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CoursesClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
@@ -40,6 +41,8 @@ import org.json.JSONTokener;
  * response is needed.
  */
 public class CoursesClient {
+
+  private static final AtomicReference<String> userAgent = new AtomicReference<>(null);
 
   /**
    * Makes a GET request to the given URL and returns the response body in a
@@ -300,6 +303,11 @@ public class CoursesClient {
 
   @NotNull
   private static String getUserAgent() {
+    String userAgentString = userAgent.get();
+    if (userAgentString != null) {
+      return userAgentString;
+    }
+
     ApplicationInfo appInfo = ApplicationInfo.getInstance();
     ApplicationNamesInfo appNamesInfo = ApplicationNamesInfo.getInstance();
     String intellijVersion = appInfo.getFullVersion();
@@ -309,7 +317,8 @@ public class CoursesClient {
     String pluginVersion = BuildInfo.INSTANCE.version.toString();
     String apacheUserAgent =
         VersionInfo.getUserAgent("Apache-HttpClient", "org.apache.http.client", VersionInfo.class);
-    return String.format(
+
+    userAgentString = String.format(
         "intellij/%s (%s; %s; %s) apluscourses/%s %s",
         intellijVersion,
         product,
@@ -317,5 +326,7 @@ public class CoursesClient {
         os,
         pluginVersion,
         apacheUserAgent);
+
+    return userAgent.compareAndSet(null, userAgentString) ? userAgentString : userAgent.get();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/Version.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/Version.java
@@ -5,11 +5,10 @@ import org.jetbrains.annotations.Nullable;
 
 public class Version {
 
-  public static final Version EMPTY = new Version(0, 0, 0);
+  public static final Version EMPTY = new Version(0, 0);
 
   public final int major;
   public final int minor;
-  public final int build;
 
   /**
    * Returns a {@link Version} object based on the value of the given string.
@@ -21,18 +20,16 @@ public class Version {
   public static Version fromString(@NotNull String versionString) {
     int major;
     int minor;
-    int build;
 
     String[] parts = versionString.split("\\.");
-    if (parts.length != 3) {
+    if (parts.length != 2) {
       throw new InvalidVersionStringException(versionString, null);
     }
 
     try {
       major = Integer.parseInt(parts[0]);
       minor = Integer.parseInt(parts[1]);
-      build = Integer.parseInt(parts[2]);
-      return new Version(major, minor, build);
+      return new Version(major, minor);
     } catch (NumberFormatException ex) {
       throw new InvalidVersionStringException(versionString, ex);
     }
@@ -58,22 +55,20 @@ public class Version {
    * A constructor for {@link Version} class.
    * @param major Major version number.
    * @param minor Minor version number.
-   * @param build Number of the build.
    * @throws IllegalArgumentException If any of the arguments are negative.
    */
-  public Version(int major, int minor, int build) {
-    if (major < 0 || minor < 0 || build < 0) {
+  public Version(int major, int minor) {
+    if (major < 0 || minor < 0) {
       throw new IllegalArgumentException("All the parts of version number must be non-negative.");
     }
     this.major = major;
     this.minor = minor;
-    this.build = build;
   }
 
   @Override
   @NotNull
   public String toString() {
-    return major + "." + minor + "." + build;
+    return major + "." + minor;
   }
 
   @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/utils/BuildInfoTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/BuildInfoTest.java
@@ -13,7 +13,7 @@ public class BuildInfoTest {
 
   @Test
   public void testCreateBuildInfoFromProperties() throws PropertyException {
-    String versionString = "1.5.18";
+    String versionString = "1.5";
 
     Properties props = new Properties();
     props.setProperty(BuildInfo.PropertyKeys.VERSION, versionString);

--- a/src/test/java/fi/aalto/cs/apluscourses/utils/VersionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/VersionTest.java
@@ -10,50 +10,39 @@ public class VersionTest {
 
   @Test
   public void testCreateVersion() {
-    Version version = new Version(3,5,24);
+    Version version = new Version(3, 5);
 
     assertEquals("The major version should be the same as that given to the constructor",
         3, version.major);
     assertEquals("The minor version should be the same as that given to the constructor",
         5, version.minor);
-    assertEquals("The build number should be the same as that given to the constructor",
-        24, version.build);
 
-    assertEquals("toString() should return the version in format '{major}.{minor}.{build}'.",
-        "3.5.24", version.toString());
+    assertEquals("toString() should return the version in format '{major}.{minor}'.",
+        "3.5", version.toString());
 
-    Version sameVersion = new Version(3, 5, 24);
+    Version sameVersion = new Version(3, 5);
     assertEquals("Version should equal to another version created with the same arguments.",
         version, sameVersion);
     assertEquals("Two equal versions should give the same hash code.",
         version.hashCode(), sameVersion.hashCode());
 
-    Version differentMajor = new Version(3, 6, 24);
+    Version differentMajor = new Version(3, 6);
     assertNotEquals("Versions with different majors versions should not be equal",
         version, differentMajor);
 
-    Version differentMinor = new Version(4, 5, 24);
+    Version differentMinor = new Version(4, 5);
     assertNotEquals("Versions with different minor versions should not be equal",
         version, differentMinor);
-
-    Version differentBuild = new Version(3, 5, 78);
-    assertNotEquals("Versions with different build numbers should not be equal",
-        version, differentBuild);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCreateVersionWithNegativeMajorVersion() {
-    new Version(-1, 4, 5);
+    new Version(-1, 4);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCreateVersionWithNegativeMinorVersion() {
-    new Version(3, -13, 1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreateVersionWithNegativeBuildNumber() {
-    new Version(7, 0, -5);
+    new Version(3, -13);
   }
 
   @Test
@@ -62,19 +51,16 @@ public class VersionTest {
 
     assertEquals(0, version.major);
     assertEquals(0, version.minor);
-    assertEquals(0, version.build);
   }
 
   @Test
   public void testCreateVersionFromValidString() {
-    Version version = Version.fromString("14.2.100");
+    Version version = Version.fromString("14.2");
 
-    assertEquals("Version created by fromString(\"14.2.100\") should have major version 4.",
+    assertEquals("Version created by fromString(\"14.2\") should have major version 4.",
         14, version.major);
-    assertEquals("Version created by fromString(\"14.2.100\") should have minor version 2.",
+    assertEquals("Version created by fromString(\"14.2\") should have minor version 2.",
         2, version.minor);
-    assertEquals("Version created by fromString(\"14.2.100\") should have build number 100.",
-        100, version.build);
   }
 
   @Test
@@ -93,17 +79,17 @@ public class VersionTest {
 
   @Test(expected = Version.InvalidVersionStringException.class)
   public void testCreateVersionFromStringMissingPart() {
-    Version.fromString("1.2");
+    Version.fromString("1");
   }
 
   @Test(expected = Version.InvalidVersionStringException.class)
   public void testCreateVersionFromStringMissingNumber() {
-    Version.fromString("9.5.");
+    Version.fromString("9.");
   }
 
   @Test(expected = Version.InvalidVersionStringException.class)
   public void testCreateVersionFromStringWithNonNumericPart() {
-    Version.fromString("6.XVII.188");
+    Version.fromString("6.XVII");
   }
 
   @Test(expected = Version.InvalidVersionStringException.class)


### PR DESCRIPTION
# Description of the PR

Closes #355 

Example:
```
User-Agent: intellij/2020.2 (IDEA; Community Edition; Windows 10) apluscourses/1.5 Apache-HttpClient/4.5.12 (Java/11.0.7)
```

This is used in API requests to
- A+
- grader.cs.hut.fi when getting the course config file

This user-agent string is not used when
- ~downloading modules/libraries/settings~ (it is!)
- opening browser (for API token, feedback, etc.)

Having information related to course there too (as suggested [here](https://github.com/Aalto-LeTech/intellij-plugin/issues/355#issuecomment-680832876)) would be more complicated thing to implement. I also don't think it should be part of user-agent string. In server side, the course can be easily inferred from the URL.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
