### PR TITLE
Add github workflow for publishing plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Publish Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Publish Plugin
+        env:
+          INTELLIJ_PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          INTELLIJ_PUBLISH_CHANNEL: test
+        run: ./gradlew publishPlugin
+ 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [prereleased]
 
 jobs:
   release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ deploy:
     script: ./gradlew publishPlugin && ./gradlew publish
     on:
       branch: master
-  - provider: script
-    script: env INTELLIJ_PUBLISH_CHANNEL=test ./gradlew publishPlugin
-    on:
-      branch: test
 
 env:
   - CI=true


### PR DESCRIPTION
The current CI process is broken, since we constantly try to publish again with the same version number leading to failed builds. This is a test/attempt at creating a GitHub workflow that is tied to prerelease tags.

Based on:
https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/.github/workflows/release.yml