### PR TITLE
Fix notifications appearing in wrong windows

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -224,7 +224,7 @@ public class SubmitExerciseAction extends AnAction {
 
     String submissionUrl = exerciseDataSource.submit(submission.buildSubmission(), authentication);
     new SubmissionStatusUpdater(
-        exerciseDataSource, authentication, submissionUrl, selectedExercise.getModel()
+        project, exerciseDataSource, authentication, submissionUrl, selectedExercise.getModel()
     ).start();
     notifier.notify(new SubmissionSentNotification(), project);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -51,11 +51,11 @@ public class InitializationActivity implements Background {
       Course.fromUrl(courseConfigurationFileUrl, new IntelliJModelFactory(project));
     } catch (UnexpectedResponseException | MalformedCourseConfigurationFileException e) {
       logger.error("Error occurred while trying to parse a course configuration file", e);
-      notifier.notify(new CourseConfigurationError(e), null);
+      notifier.notify(new CourseConfigurationError(e), project);
       return;
     } catch (IOException e) {
       logger.info("IOException occurred while using the HTTP client", e);
-      notifier.notify(new NetworkErrorNotification(e), null);
+      notifier.notify(new NetworkErrorNotification(e), project);
       return;
     }
     pluginSettings.createUpdatingMainViewModel(project);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -1,12 +1,17 @@
 package fi.aalto.cs.apluscourses.model;
 
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 
 public class SubmissionStatusUpdater {
+
+  @NotNull
+  private final Project project;
 
   @NotNull
   private final ExerciseDataSource dataSource;
@@ -45,7 +50,8 @@ public class SubmissionStatusUpdater {
   /**
    * Construct a submission status updater with the given parameters.
    */
-  public SubmissionStatusUpdater(@NotNull ExerciseDataSource dataSource,
+  public SubmissionStatusUpdater(@NotNull Project project,
+                                 @NotNull ExerciseDataSource dataSource,
                                  @NotNull Authentication authentication,
                                  @NotNull Notifier notifier,
                                  @NotNull String submissionUrl,
@@ -53,6 +59,7 @@ public class SubmissionStatusUpdater {
                                  long interval,
                                  long increment,
                                  long timeLimit) {
+    this.project = project;
     this.dataSource = dataSource;
     this.authentication = authentication;
     this.notifier = notifier;
@@ -68,11 +75,13 @@ public class SubmissionStatusUpdater {
   /**
    * Construct a submission status updater with reasonable defaults for the time values.
    */
-  public SubmissionStatusUpdater(@NotNull ExerciseDataSource dataSource,
+  public SubmissionStatusUpdater(@NotNull Project project,
+                                 @NotNull ExerciseDataSource dataSource,
                                  @NotNull Authentication authentication,
                                  @NotNull String submissionUrl,
                                  @NotNull Exercise exercise) {
     this(
+        project,
         dataSource,
         authentication,
         Notifications.Bus::notify,
@@ -100,7 +109,7 @@ public class SubmissionStatusUpdater {
           submissionResult =
               dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
           if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
-            notifier.notify(new FeedbackAvailableNotification(submissionResult, exercise),null);
+            notifier.notify(new FeedbackAvailableNotification(submissionResult, exercise), project);
             return;
           }
         } catch (IOException e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -2,7 +2,6 @@ package fi.aalto.cs.apluscourses.model;
 
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import java.io.IOException;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -6,10 +6,11 @@ import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotifica
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SubmissionStatusUpdater {
 
-  @NotNull
+  @Nullable
   private final Project project;
 
   @NotNull
@@ -49,7 +50,7 @@ public class SubmissionStatusUpdater {
   /**
    * Construct a submission status updater with the given parameters.
    */
-  public SubmissionStatusUpdater(@NotNull Project project,
+  public SubmissionStatusUpdater(@Nullable Project project,
                                  @NotNull ExerciseDataSource dataSource,
                                  @NotNull Authentication authentication,
                                  @NotNull Notifier notifier,
@@ -74,7 +75,7 @@ public class SubmissionStatusUpdater {
   /**
    * Construct a submission status updater with reasonable defaults for the time values.
    */
-  public SubmissionStatusUpdater(@NotNull Project project,
+  public SubmissionStatusUpdater(@Nullable Project project,
                                  @NotNull ExerciseDataSource dataSource,
                                  @NotNull Authentication authentication,
                                  @NotNull String submissionUrl,

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,6 +55,7 @@ public class SubmissionStatusUpdaterTest {
   @Test
   public void testSubmissionStatusUpdater() throws InterruptedException {
     new SubmissionStatusUpdater(
+        mock(Project.class),
         dataSource,
         mock(Authentication.class),
         notifier,
@@ -67,13 +69,14 @@ public class SubmissionStatusUpdaterTest {
 
     assertEquals("The submission results are not fetched anymore after feedback is available",
         3, dataSource.getSubmissionResultFetchCount());
-    verify(notifier).notify(any(FeedbackAvailableNotification.class), isNull());
+    verify(notifier).notify(any(FeedbackAvailableNotification.class), any(Project.class));
   }
 
   @Test
   public void testSubmissionStatusUpdaterTimeLimit() throws InterruptedException {
     dataSource.limit = 9999;
     new SubmissionStatusUpdater(
+        mock(Project.class),
         dataSource,
         mock(Authentication.class),
         notifier,

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -3,7 +3,7 @@ package fi.aalto.cs.apluscourses.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -45,17 +45,22 @@ public class SubmissionStatusUpdaterTest {
 
   private TestDataSource dataSource;
   private Notifier notifier;
+  private Project project;
 
+  /**
+   * Initialize mock objects and a {@link TestDataSource}. Called before every test.
+   */
   @Before
   public void setUp() {
     dataSource = new TestDataSource();
     notifier = mock(Notifier.class);
+    project = mock(Project.class);
   }
 
   @Test
   public void testSubmissionStatusUpdater() throws InterruptedException {
     new SubmissionStatusUpdater(
-        mock(Project.class),
+        project,
         dataSource,
         mock(Authentication.class),
         notifier,
@@ -69,14 +74,14 @@ public class SubmissionStatusUpdaterTest {
 
     assertEquals("The submission results are not fetched anymore after feedback is available",
         3, dataSource.getSubmissionResultFetchCount());
-    verify(notifier).notify(any(FeedbackAvailableNotification.class), any(Project.class));
+    verify(notifier).notify(any(FeedbackAvailableNotification.class), same(project));
   }
 
   @Test
   public void testSubmissionStatusUpdaterTimeLimit() throws InterruptedException {
     dataSource.limit = 9999;
     new SubmissionStatusUpdater(
-        mock(Project.class),
+        project,
         dataSource,
         mock(Authentication.class),
         notifier,


### PR DESCRIPTION
# Description of the PR
Some notifiers used null instead of project, so the notifications could appear in wrong windows

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
