### PR TITLE
Optional filter

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -400,26 +400,28 @@ available. Click here to open the feedback.** notification is shown.
 
 **12.1** Click **Filter Assignments** button (pink funnel icon) above the assignments tree.
 
-**12.2** ASSERTION: **Non-submittable** menu item is checked.
+**12.2** ASSERTION: **Non-submittable** and **Optional** menu items are checked.
 
 **12.3** Uncheck **Non-submittable** menu item.  Note: This makes the exercise tree to collapse.
 
 **12.4** ASSERTION: Non-submittable (that is, grayed out) assignments are no longer in the tree.
 
-**12.5** Check **Non-submittable** menu item again.
+**12.5** Uncheck **Optional** menu item.
 
-**12.6** ASSERTION: Non-submittable assignments are shown again in the tree.
+**12.6** ASSERTION: Optional assignments are invisible and Non-submittable assignments are still invisible.
 
-**12.7** Uncheck **Non-submittable** menu item again.
+**12.7** Check **Non-submittable** menu item again.
 
-**12.8** Restart the IDE.
+**12.8** ASSERTION: Non-submittable assignments are shown again in the tree and Optional assignments aren't.
 
-**12.9** ASSERTION: Non-submittable assignments are still invisible.
+**12.9** Restart the IDE.
 
-**12.10** ASSERTION: **Non-submittable** menu item is unchecked.
+**12.10** ASSERTION: Optional assignments are still invisible and Non-submittable assignments are visible.
 
-**12.11** From the main menu, choose **A+ > Reset A+ Courses Plugin Settings**.
+**12.11** ASSERTION: **Non-submittable** menu item is checked and **Optional** is unchecked.
 
-**12.12** ASSERTION: Non-submittable assignments are shown again in the tree.
+**12.12** From the main menu, choose **A+ > Reset A+ Courses Plugin Settings**.
 
-**12.12** ASSERTION: **Non-submittable** menu item is checked.
+**12.13** ASSERTION: Non-submittable and Optional assignments are shown again in the tree.
+
+**12.14** ASSERTION: **Non-submittable** and **Optional** menu items are checked.

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -37,7 +37,8 @@ public class PluginSettings implements MainViewModelProvider {
     A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG("A+.showReplConfigDialog"),
     A_PLUS_IMPORTED_IDE_SETTINGS("A+.importedIdeSettings"),
     A_PLUS_SHOW_NON_SUBMITTABLE("A+.showNonSubmittable"),
-    A_PLUS_SHOW_COMPLETED("A+.showCompleted");
+    A_PLUS_SHOW_COMPLETED("A+.showCompleted"),
+    A_PLUS_SHOW_OPTIONAL("A+.showOptional");
 
     private final String name;
 
@@ -112,7 +113,11 @@ public class PluginSettings implements MainViewModelProvider {
       new IntelliJFilterOption(LocalIdeSettingsNames.A_PLUS_SHOW_COMPLETED,
           getText("presentation.exerciseFilterOptions.Completed"),
           null,
-          new ExerciseFilter.CompletedFilter()));
+          new ExerciseFilter.CompletedFilter()),
+      new IntelliJFilterOption(LocalIdeSettingsNames.A_PLUS_SHOW_OPTIONAL,
+          getText("presentation.exerciseFilterOptions.Optional"),
+          null,
+          new ExerciseFilter.OptionalFilter()));
 
   private final ProjectManagerListener projectManagerListener = new ProjectManagerListener() {
     @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -122,8 +122,13 @@ public class Exercise {
     return maxSubmissions;
   }
 
+  /**
+   * Returns true if assignment is completed.
+   * @return True if userPoints are the same as maxPoints, otherwise False
+   */
   public boolean isCompleted() {
     // Optional assignments are never completed, since they can be filtered separately
+    // and we can't tell from the points whether the submission was correct or not
     return userPoints == maxPoints && !isOptional();
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -123,7 +123,12 @@ public class Exercise {
   }
 
   public boolean isCompleted() {
-    return userPoints == maxPoints && submissionResults.size() > 0;
+    // Optional assignments are never completed, since they can be filtered separately
+    return userPoints == maxPoints && !isOptional();
+  }
+
+  public boolean isOptional() {
+    return maxSubmissions == 0 && maxPoints == 0;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseFilter.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseFilter.java
@@ -20,4 +20,11 @@ public abstract class ExerciseFilter extends TypedFilter<ExerciseViewModel> {
       return item.getModel().isCompleted();
     }
   }
+
+  public static class OptionalFilter extends ExerciseFilter {
+    @Override
+    public boolean applyInternal(ExerciseViewModel item) {
+      return item.getModel().isOptional();
+    }
+  }
 }

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -51,6 +51,7 @@ presentation.dependencyStatus.errorInDependencies=Error in dependencies
 
 presentation.exerciseFilterOptions.nonSubmittable=Non-submittable
 presentation.exerciseFilterOptions.Completed=Completed
+presentation.exerciseFilterOptions.Optional=Optional
 
 # UI
 ## REPL

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -183,7 +183,7 @@ public class ExerciseTest {
             optional.isOptional());
 
     Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", 0, 5, 10);
-    assertFalse("Assingment isn't optional",
+    assertFalse("Assignment isn't optional",
         notOptional.isOptional());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -155,7 +155,7 @@ public class ExerciseTest {
 
     assertFalse("Optional assignment with no submissions isn't completed",
         optionalNotSubmitted.isCompleted());
-    assertTrue("Optional assignment with submissions is completed",
+    assertFalse("Optional assignment with submissions isn't completed",
         optionalSubmitted.isCompleted());
 
     Exercise noSubmissions = new Exercise(3, "noSubmissions", "http://localhost:1111", 0, 5, 10);
@@ -174,5 +174,16 @@ public class ExerciseTest {
         failed.isCompleted());
     assertTrue("Assignment with full user points is completed",
         completed.isCompleted());
+  }
+
+  @Test
+  public void testIsOptional() {
+    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", 0, 0, 0);
+    assertTrue("Assignment is optional",
+            optional.isOptional());
+
+    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", 0, 5, 10);
+    assertFalse("Assingment isn't optional",
+        notOptional.isOptional());
   }
 }


### PR DESCRIPTION
# Description of the PR
Filter for optional assignments. This way past weeks with non-completed optional assignments can be hidden

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [x] Yes
- [ ] Not yet. I will do it next.
- [ ] Not relevant
