### PR TITLE
Add possibility to select default group

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -13,9 +13,9 @@ Manual testing
 ### 0 Setup
 
 **0.1** Make sure you are using a clean installment of
-        **IntelliJ IDEA Community** version **2020.2**.
+        **IntelliJ IDEA Community** version **2020.2.2**.
 - You can download IntelliJ IDEA Community from https://www.jetbrains.com/idea/download.
-- In case you use pre-existing installment of IntelliJ IDEA,
+- In case you use an existing install of IntelliJ IDEA,
   you can use one of the following ways to restore to the default settings:
 
 **0.1.A.** In the main window, choose **File > Manage IDE Settings > Restore Default Settings...**
@@ -64,15 +64,15 @@ Manual testing
 
 **1.3** ASSERTION: IntelliJ IDEA asks to install **Scala Plugin**.
 
-**1.4** ASSERTION: IntelliJ IDEA requires a restart.
+**1.4** Install **Scala Plugin** by clicking **OK**.
 
-**1.5** Install **Scala Plugin** by clicking **OK**.
+**1.5** ASSERTION: IntelliJ IDEA requires a restart.
 
 **1.6** Restart IntelliJ IDEA.
 
 ### 2 Initialize a new project
 
-**2.1** In the startup window, click **Create New Project**.
+**2.1** In the startup window, click **New Project**.
 
 **2.2** In **New Project** window, choose **Empty Project** on a left-hand side list.
 
@@ -80,7 +80,7 @@ Manual testing
 
 **2.4** On the next view, click **Finish**.
 
-**2.5** If **Tip of the Day** window is shown,
+**2.5** If the **Tip of the Day** window is shown,
         check **Don't show tips** and click **Close**. 
 
 **2.6** ASSERTION: **Project Structure** window opens with **Modules** tab visible.
@@ -101,9 +101,9 @@ Manual testing
 
 ### 3 About window
 
-**3.1** From the main menu, choose **A+ > About A+ Plugin**.
+**3.1** From the main menu, choose **A+ > About the A+ Courses Plugin**.
 
-**3.2** The about window is shown.
+**3.2** ASSERTION: The information window is shown.
 
 **3.3** Click the highlighted **A+ Courses Plugin website** link.
 
@@ -117,13 +117,13 @@ Manual testing
 
 **4.2** On the dialog that opens, click **Cancel**.
 
-**4.3** ASSERTION: The dialog closes but nothing else seems to happen.
+**4.3** ASSERTION: The dialog closes and nothing else seems to happen.
 
 **4.4** Open **A+ > Turn project into A+ course project** again.
 
-**4.5** ASSERTION: **Leave IntelliJ settings unchanged** checkbutton is not checked.
+**4.5** ASSERTION: **Leave IntelliJ settings unchanged** check box is not checked.
 
-**4.6** Check "leave unchanged" checkbox.
+**4.6** Check the "leave unchanged" check box.
 
 **4.7** Select the desired language of assignments submission and click **OK**.
 
@@ -137,7 +137,7 @@ Manual testing
 
 **4.11** Once again, navigate to **A+ > Turn project into A+ course project**.
 
-**4.12** Leave the checkbox unchecked and click **OK**.
+**4.12** Leave the settings opt-out check box unchecked, select a language, and click **OK**.
 
 **4.13** The screen shows a dialog that tells the IDE will be restarted.
 
@@ -256,15 +256,15 @@ imported packages: **o1, o1.llama, o1.randomtext**.
 
 **6.24** Reopen REPL by choosing a folder or a file within **O1Library** module.
 
-**6.25** This time, leave **Don't show this window again** checkbox checked.
+**6.25** Change **Working directory** to be the directory of **SwingExamples** module.
 
-**6.26** Change **Working directory** to be the directory of **SwingExamples** module.
+**6.26** This time, leave **Don't show this window again** checkbox checked.
 
 **6.27** Click **OK**.
 
-**6.28** ASSERTION: A REPL opens with **O1Library** in its title.
+**6.28** ASSERTION: A Scala REPL opens with **O1Library** in its title.
 
-**6.29** In REPL, execute the same two commands as in **6.9**.
+**6.29** In the REPL, execute the same two commands as in **6.9**.
 
 **6.30** ASSERTION: The output of the first statement is the directory of **SwingExamples** module.
 
@@ -290,13 +290,14 @@ imported packages: **o1, o1.llama, o1.randomtext**.
 
 **6.39** Close the REPL.
 
-**6.40** Restart te IDE.
+**6.40** Restart the IDE.
 
-**6.41** Once the IDE has restarted, open the REPL by choosing any file.
+**6.41** Once the IDE has restarted, open a file from **O1Library** in the editor
+         and start the Scala REPL.
 
 **6.42** ASSERTION: **REPL Configuration** window does not show up.
 
-**6.43** ASSERTION: A REPL opens.
+**6.43** ASSERTION: A Scala REPL for **O1Library** opens.
 
 **6.44** Close the REPL.
 
@@ -304,7 +305,7 @@ imported packages: **o1, o1.llama, o1.randomtext**.
 
 **6.45** From the main menu, choose **A+ > Reset A+ Courses Plugin Settings**.
 
-**6.46** Open REPL by choosing any file.
+**6.46** Open the Scala REPL for **O1Library**.
 
 **6.47** ASSERTION: **REPL Configuration** window shows up.
 
@@ -323,7 +324,8 @@ imported packages: **o1, o1.llama, o1.randomtext**.
 
 **7.4** Double click **SwingExamples** in **Modules** list.
 
-**7.5** ASSERTION: **SwingExamples** shows up as a module in the project tree.
+**7.5** ASSERTION: **SwingExamples** shows up as a module in the project tree
+        and its status changes to **Installed** in the modules list.
 
 ### 8 Authentication with A+ LMS
 
@@ -341,16 +343,15 @@ imported packages: **o1, o1.llama, o1.randomtext**.
 
 ![Assignments shown](images/assignments-shown.png)
 
-**8.6** Close the IDE.
+**8.6** Restart the IDE.
 
-**8.7** Open the IDE with the project.
- 
-**8.8** ASSERTION: Assignments tab is still populated. If [safe password storage](https://jetbrains.org/intellij/sdk/docs/basics/persisting_sensitive_data.html?search=sensitive#storage) 
-is activated in the OS.
+**8.7** ASSERTION: All the assignments are listed in the assignments tab, assuming that the
+        [safe password storage](https://jetbrains.org/intellij/sdk/docs/basics/persisting_sensitive_data.html?search=sensitive#storage) 
+        is enabled in the OS.
 
 ### 9 Assignments submission
 
-**9.1** Expand **Week 1** and select **Assignment 2 (GoodStuff)**, and hit 
+**9.1** Expand **Week 1**, select **Assignment 2 (GoodStuff)**, and hit 
 **Submit A+ Assignment**.
 
 ![Submit](images/submit_button.png)
@@ -358,17 +359,21 @@ is activated in the OS.
 **9.2** ASSERTION: The **Could not find module: The A+ Courses plugin could not find the 
 module GoodStuff.** error is shown.
 
-**9.3** Go to **Modules** tab and install **GoodStuff** module like described in **6.1**
+**9.3** Go to **Modules** tab and install **GoodStuff** module like described in **5.1**
 
 **9.4** Repeat **9.1**.
 
 **9.5** ASSERTION: **Submit Assignment** dialog is shown.
 
-**9.6** Select **Submit as: > Submit alone**, click **OK**.
+**9.6** Select **Submit as: > Submit alone**, check the default group check box, and click **OK**.
 
-**9.7** ASSERTION: The **Assignment successfully sent for assessment: You will be notified here when
+**9.7** ASSERTION: The **Assignment sent for assessment: You will be notified here when
  feedback is available. (You may also always check any ... )** notification is shown.
  
+**9.8** Repeat **9.1**.
+
+**9.9** ASSERTION: The default group check box is checked and the group selection shows **Submit alone**.
+
 ### 10 Refreshing Modules and Assignments
 
 **10.1** Hit the **Refresh Assignments** or **Refresh Modules** button.

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -215,11 +215,27 @@ public class SubmitExerciseAction extends AnAction {
     groups.add(0, new Group(-1, Collections
         .singletonList(getText("ui.toolWindow.subTab.exercises.submission.submitAlone"))));
 
-    SubmissionViewModel submission =
-        new SubmissionViewModel(exercise, submissionInfo, history, groups, files, language);
+    // Find the group from the available groups that matches the default group ID.
+    // A group could be removed, so this way we check that the default group ID is still valid.
+    Optional<Long> defaultGroupId = PluginSettings.getInstance().getDefaultGroupId();
+    Group defaultGroup = defaultGroupId
+        .flatMap(id -> groups
+            .stream()
+            .filter(group -> group.getId() == id)
+            .findFirst())
+        .orElse(null);
+
+    SubmissionViewModel submission = new SubmissionViewModel(
+        exercise, submissionInfo, history, groups, defaultGroup, files, language);
 
     if (!dialogs.create(submission, project).showAndGet()) {
       return;
+    }
+
+    if (Boolean.TRUE.equals(submission.makeDefaultGroup.get())) {
+      PluginSettings.getInstance().setDefaultGroupId(submission.selectedGroup.get().getId());
+    } else {
+      PluginSettings.getInstance().clearDefaultGroupId();
     }
 
     String submissionUrl = exerciseDataSource.submit(submission.buildSubmission(), authentication);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.services;
 
+import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalIdeSettingsNames.A_PLUS_DEFAULT_GROUP;
 import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalIdeSettingsNames.A_PLUS_IMPORTED_IDE_SETTINGS;
 import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalIdeSettingsNames.A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
@@ -20,6 +21,7 @@ import fi.aalto.cs.apluscourses.presentation.exercise.ExerciseFilter;
 import fi.aalto.cs.apluscourses.presentation.filter.Option;
 import fi.aalto.cs.apluscourses.presentation.filter.Options;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +38,7 @@ public class PluginSettings implements MainViewModelProvider {
   public enum LocalIdeSettingsNames {
     A_PLUS_SHOW_REPL_CONFIGURATION_DIALOG("A+.showReplConfigDialog"),
     A_PLUS_IMPORTED_IDE_SETTINGS("A+.importedIdeSettings"),
+    A_PLUS_DEFAULT_GROUP("A+.defaultGroup"),
     A_PLUS_SHOW_NON_SUBMITTABLE("A+.showNonSubmittable"),
     A_PLUS_SHOW_COMPLETED("A+.showCompleted"),
     A_PLUS_SHOW_OPTIONAL("A+.showOptional");
@@ -239,6 +242,19 @@ public class PluginSettings implements MainViewModelProvider {
 
   public void setImportedIdeSettingsId(@NotNull String courseId) {
     applicationPropertiesManager.setValue(A_PLUS_IMPORTED_IDE_SETTINGS.getName(), courseId);
+  }
+
+  public Optional<Long> getDefaultGroupId() {
+    String id = applicationPropertiesManager.getValue(A_PLUS_DEFAULT_GROUP.getName());
+    return Optional.ofNullable(id).map(Long::parseLong);
+  }
+
+  public void setDefaultGroupId(long groupId) {
+    applicationPropertiesManager.setValue(A_PLUS_DEFAULT_GROUP.getName(), String.valueOf(groupId));
+  }
+
+  public void clearDefaultGroupId() {
+    applicationPropertiesManager.unsetValue(A_PLUS_DEFAULT_GROUP.getName());
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -38,6 +38,9 @@ public class SubmissionViewModel {
   public final ObservableProperty<Group> selectedGroup =
       new ObservableReadWriteProperty<>(null, SubmissionViewModel::validateGroupSelection);
 
+  public final ObservableProperty<Boolean> makeDefaultGroup =
+      new ObservableReadWriteProperty<>(false);
+
   @Nullable
   private static ValidationError validateGroupSelection(@Nullable Group group) {
     return group == null ? new GroupNotSelectedError() : null;
@@ -50,6 +53,7 @@ public class SubmissionViewModel {
                              @NotNull SubmissionInfo submissionInfo,
                              @NotNull SubmissionHistory submissionHistory,
                              @NotNull List<Group> availableGroups,
+                             @Nullable Group defaultGroup,
                              @NotNull Map<String, Path> filePaths,
                              @NotNull String language) {
     this.exercise = exercise;
@@ -59,6 +63,10 @@ public class SubmissionViewModel {
     this.filePaths = filePaths;
     this.language = language;
     this.submittableFiles = submissionInfo.getFiles(language).toArray(new SubmittableFile[0]);
+    if (defaultGroup != null) {
+      selectedGroup.set(defaultGroup);
+      makeDefaultGroup.set(true);
+    }
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="fi.aalto.cs.apluscourses.ui.exercise.SubmissionDialog">
-  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="11" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="12" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -33,13 +33,13 @@
       </component>
       <component id="46e37" class="javax.swing.JLabel" binding="submissionCount" custom-create="true">
         <constraints>
-          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="acd" class="javax.swing.JLabel" binding="filenames" custom-create="true">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -58,45 +58,53 @@
       </vspacer>
       <component id="4eb0e" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <vspacer id="527aa">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>
       <hspacer id="a5085">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="4" height="-1"/>
           </grid>
         </constraints>
       </hspacer>
       <hspacer id="b5056">
         <constraints>
-          <grid row="8" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="9" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="4" height="-1"/>
           </grid>
         </constraints>
       </hspacer>
       <vspacer id="7440b">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>
       <component id="1d5dd" class="javax.swing.JLabel" binding="warning">
         <constraints>
-          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <foreground color="-65536"/>
           <text value=""/>
+        </properties>
+      </component>
+      <component id="abf79" class="fi.aalto.cs.apluscourses.ui.base.CheckBox" binding="defaultGroupCheckBox">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Default to this group in future submissions."/>
         </properties>
       </component>
     </children>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
@@ -7,6 +7,7 @@ import fi.aalto.cs.apluscourses.model.Group;
 import fi.aalto.cs.apluscourses.model.SubmittableFile;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionViewModel;
 import fi.aalto.cs.apluscourses.ui.GuiObject;
+import fi.aalto.cs.apluscourses.ui.base.CheckBox;
 import fi.aalto.cs.apluscourses.ui.base.OurComboBox;
 import fi.aalto.cs.apluscourses.ui.base.OurDialogWrapper;
 import javax.swing.Action;
@@ -28,6 +29,8 @@ public class SubmissionDialog extends OurDialogWrapper {
 
   protected OurComboBox<Group> groupComboBox;
 
+  protected CheckBox defaultGroupCheckBox;
+
   protected JLabel submissionCount;
 
   @GuiObject
@@ -47,6 +50,8 @@ public class SubmissionDialog extends OurDialogWrapper {
 
     groupComboBox.selectedItemBindable.bindToSource(viewModel.selectedGroup);
     registerValidationItem(groupComboBox.selectedItemBindable);
+
+    defaultGroupCheckBox.isCheckedBindable.bindToSource(viewModel.makeDefaultGroup);
 
     warning.setText(viewModel.getSubmissionWarning());
 

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -2,8 +2,10 @@ package fi.aalto.cs.apluscourses.presentation.exercise;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.Group;
@@ -47,7 +49,7 @@ public class SubmissionViewModelTest {
     Exercise exercise = new Exercise(100, "Exercise", "http://localhost:1000", 0, 0, 0);
 
     SubmissionViewModel submissionViewModel =
-        new SubmissionViewModel(exercise, submissionInfo, history, groups, fileMap, language);
+        new SubmissionViewModel(exercise, submissionInfo, history, groups, null, fileMap, language);
 
     assertNotNull("The validation should fail when no group is yet selected",
         submissionViewModel.selectedGroup.validate());
@@ -59,7 +61,7 @@ public class SubmissionViewModelTest {
     SubmissionInfo info = new SubmissionInfo(5, Collections.emptyMap());
 
     SubmissionViewModel submissionViewModel1 = new SubmissionViewModel(exercise, info,
-        new SubmissionHistory(3), Collections.emptyList(), Collections.emptyMap(), "");
+        new SubmissionHistory(3), Collections.emptyList(), null, Collections.emptyMap(), "");
 
     assertEquals(4, submissionViewModel1.getCurrentSubmissionNumber());
     assertEquals("You are about to make submission 4 out of 5.",
@@ -67,14 +69,14 @@ public class SubmissionViewModelTest {
     assertNull(submissionViewModel1.getSubmissionWarning());
 
     SubmissionViewModel submissionViewModel2 = new SubmissionViewModel(exercise, info,
-        new SubmissionHistory(4), Collections.emptyList(), Collections.emptyMap(), "");
+        new SubmissionHistory(4), Collections.emptyList(), null, Collections.emptyMap(), "");
 
     assertEquals("You are about to make submission 5 out of 5.",
         submissionViewModel2.getSubmissionCountText());
     assertNotNull(submissionViewModel2.getSubmissionWarning());
 
     SubmissionViewModel submissionViewModel3 = new SubmissionViewModel(exercise, info,
-        new SubmissionHistory(5), Collections.emptyList(), Collections.emptyMap(), "");
+        new SubmissionHistory(5), Collections.emptyList(), null, Collections.emptyMap(), "");
 
     assertEquals("You are about to make submission 6 out of 5.",
         submissionViewModel3.getSubmissionCountText());
@@ -83,7 +85,7 @@ public class SubmissionViewModelTest {
     // Max submissions 0
     SubmissionInfo practiceAssignment = new SubmissionInfo(0, Collections.emptyMap());
     SubmissionViewModel submissionViewModel4 = new SubmissionViewModel(exercise, practiceAssignment,
-        new SubmissionHistory(2), Collections.emptyList(), Collections.emptyMap(), "");
+        new SubmissionHistory(2), Collections.emptyList(), null, Collections.emptyMap(), "");
 
     assertEquals("You are about to make submission 3.",
         submissionViewModel4.getSubmissionCountText());
@@ -106,10 +108,34 @@ public class SubmissionViewModelTest {
     SubmissionHistory history = new SubmissionHistory(0);
 
     SubmissionViewModel submission = new SubmissionViewModel(
-        exercise, info, history, Collections.emptyList(), Collections.emptyMap(), "fi"
+        exercise, info, history, Collections.emptyList(), null, Collections.emptyMap(), "fi"
     );
 
     assertArrayEquals("getFiles returns the files corresponding to the given language",
         new SubmittableFile[] {finnishFile1, finnishFile2}, submission.getFiles());
+  }
+
+  @Test
+  public void testDefaultGroup() {
+    Exercise exercise = new Exercise(1000, "wow", "http://www.fi", 0, 0, 0);
+    SubmissionInfo info = new SubmissionInfo(0, Collections.emptyMap());
+    SubmissionHistory history = new SubmissionHistory(0);
+    Group group = new Group(1, Arrays.asList("Jyrki", "Jorma"));
+    List<Group> availableGroups = Collections.singletonList(group);
+
+    SubmissionViewModel viewModel1 = new SubmissionViewModel(
+        exercise, info, history, availableGroups, null, Collections.emptyMap(), "fi"
+    );
+    SubmissionViewModel viewModel2 = new SubmissionViewModel(
+        exercise, info, history, availableGroups, group, Collections.emptyMap(), "fi"
+    );
+
+    assertNull(viewModel1.selectedGroup.get());
+    assertNotNull(viewModel2.selectedGroup.get());
+
+    assertFalse("The default group check box is unchecked when no default group exists",
+        viewModel1.makeDefaultGroup.get());
+    assertTrue("The default group check box is automatically checked if a default group exists",
+        viewModel2.makeDefaultGroup.get());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
@@ -5,15 +5,21 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.intellij.testFramework.LightIdeaTestCase;
+import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.Group;
+import fi.aalto.cs.apluscourses.model.SubmissionHistory;
+import fi.aalto.cs.apluscourses.model.SubmissionInfo;
 import fi.aalto.cs.apluscourses.model.SubmittableFile;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionViewModel;
+import fi.aalto.cs.apluscourses.ui.base.CheckBox;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.Action;
 import javax.swing.ComboBoxModel;
 import javax.swing.JComboBox;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,6 +38,10 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
       return super.groupComboBox;
     }
 
+    public CheckBox getDefaultGroupCheckBox() {
+      return super.defaultGroupCheckBox;
+    }
+
     public String getSubmissionNumberText() {
       return super.submissionCount.getText();
     }
@@ -43,31 +53,37 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
   }
 
   @NotNull
-  private SubmissionViewModel createMockViewModel(@NotNull String exerciseName,
-                                                  @NotNull List<Group> availableGroups,
-                                                  @NotNull SubmittableFile[] files,
-                                                  int numberOfSubmissions,
-                                                  int maxNumberOfSubmissions) {
-    SubmissionViewModel viewModel = mock(SubmissionViewModel.class);
-    doReturn(exerciseName).when(viewModel).getPresentableExerciseName();
-    doReturn(availableGroups).when(viewModel).getAvailableGroups();
-    doReturn(files).when(viewModel).getFiles();
-    doReturn("You are about to make submission 4 out of 10.")
-        .when(viewModel)
-        .getSubmissionCountText();
-    return viewModel;
+  private SubmissionViewModel createViewModel(@NotNull String exerciseName,
+                                              @NotNull List<Group> availableGroups,
+                                              @Nullable Group defaultGroup,
+                                              @NotNull List<SubmittableFile> files,
+                                              int numberOfSubmissions,
+                                              int maxNumberOfSubmissions) {
+    return new SubmissionViewModel(
+        new Exercise(1, exerciseName, "http://www.fi", 0, 0, maxNumberOfSubmissions),
+        new SubmissionInfo(maxNumberOfSubmissions, Collections.singletonMap("en", files)),
+        new SubmissionHistory(numberOfSubmissions),
+        availableGroups,
+        defaultGroup,
+        Collections.emptyMap(),
+        "en"
+    );
   }
 
   @NotNull
   private TestDialog createTestDialog() {
     return new TestDialog(
-        createMockViewModel(
+        createViewModel(
             "Cool Name",
-            Arrays.asList(new Group(123, Arrays.asList("Jarkko", "Petteri"))),
-            new SubmittableFile[] {
+            Arrays.asList(
+                new Group(123, Arrays.asList("Jarkko", "Petteri")),
+                new Group(456, Arrays.asList("Annika", "Katariina"))
+            ),
+            new Group(456, Arrays.asList("Annika", "Katariina")),
+            Arrays.asList(
                 new SubmittableFile("file1", "main.c"),
                 new SubmittableFile("file2", "main.h")
-            },
+            ),
             4,
             10
         )
@@ -97,13 +113,27 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
     ComboBoxModel<Group> model = comboBox.getModel();
     Assert.assertEquals("The group selection combo box includes available groups", 123,
         model.getElementAt(0).getId());
+    Assert.assertEquals("The group selection combo box includes available groups", 456,
+        model.getElementAt(1).getId());
+    Assert.assertEquals("The selected item is the default group", 456,
+        ((Group) model.getSelectedItem()).getId());
+  }
+
+  @Test
+  public void testSubmissionDialogDefaultGroupCheckBox() {
+    TestDialog testDialog = createTestDialog();
+    CheckBox checkBox = testDialog.getDefaultGroupCheckBox();
+    Assert.assertTrue(
+        "The default group check box is bound to the observable property in the view model",
+        checkBox.isSelected()
+    );
   }
 
   @Test
   public void testSubmissionDialogSubmissionCountText() {
     TestDialog testDialog = createTestDialog();
     Assert.assertEquals("The submission count text is correct",
-        "You are about to make submission 4 out of 10.", testDialog.getSubmissionNumberText());
+        "You are about to make submission 5 out of 10.", testDialog.getSubmissionNumberText());
   }
 
   @Test


### PR DESCRIPTION
# Description of the PR

This PR adds a check box that makes the submission group the default value of the combo box in future submissions. Importantly, the group combo box is still there in future submissions, so the group can still be changed. The check box is also always visible, and it is checked by default if a default group exists. Unchecking the check box manually removes the default group from future submissions (analogous to a settings reset).

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [x] Not yet. I will do it next.
- [ ] Not relevant
