### PR TITLE
Unify plugin publishing for test and stable version

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,8 +1,8 @@
-name: Release
+name: Pre-release
 
 on:
   release:
-    types: [released]
+    types: [prereleased]
 
 jobs:
   release:
@@ -22,5 +22,6 @@ jobs:
       - name: Publish Plugin
         env:
           INTELLIJ_PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          INTELLIJ_PUBLISH_CHANNEL: test
         run: ./gradlew publishPlugin
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,5 @@ addons:
 script:
   - chmod +x start_local_a+_env.sh && ./start_local_a+_env.sh && ./gradlew check && sonar-scanner
 
-deploy:
-  - provider: script
-    script: ./gradlew publishPlugin && ./gradlew publish
-    on:
-      branch: master
-
 env:
   - CI=true


### PR DESCRIPTION
# Description of the PR

Adds a workflow that gets triggered by a new release. This is very similar to the existing workflow that gets triggered by a pre-release, except that it publishes to the stable channel instead of the test channel. Closes #310.
 
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
