### PR TITLE
Fix javadoc errors

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
@@ -2,16 +2,15 @@ package fi.aalto.cs.apluscourses.intellij.utils;
 
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleOrderEntry;
-import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.roots.RootPolicy;
-import fi.aalto.cs.apluscourses.intellij.model.IntelliJComponent;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class is a {@link RootPolicy} that builds a list of the names of those {@link OrderEntry}
- * objects that represents dependencies of an {@link IntelliJComponent} object (that is, modules
+ * This class is a {@link RootPolicy} that builds a list of the names of those
+ * {@link com.intellij.openapi.roots.OrderEntry} objects that represents dependencies of an
+ * {@link fi.aalto.cs.apluscourses.intellij.model.IntelliJComponent} object (that is, modules
  * and non-module-level libraries).
  */
 public class ListDependenciesPolicy extends RootPolicy<List<String>> {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
@@ -7,9 +7,9 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class is a {@RootPolicy} that builds a list of the names of those {@OrderEntry} objects that
- * represents dependencies of an {@IntelliJComponent} object (that is, modules and non-module-level
- * libraries).
+ * This class is a {@link RootPolicy} that builds a list of the names of those {@code OrderEntry}
+ * objects that represents dependencies of an {@code IntelliJComponent} object (that is, modules
+ * and non-module-level libraries).
  */
 public class ListDependenciesPolicy extends RootPolicy<List<String>> {
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ListDependenciesPolicy.java
@@ -2,13 +2,16 @@ package fi.aalto.cs.apluscourses.intellij.utils;
 
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleOrderEntry;
+import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.roots.RootPolicy;
+import fi.aalto.cs.apluscourses.intellij.model.IntelliJComponent;
 import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class is a {@link RootPolicy} that builds a list of the names of those {@code OrderEntry}
- * objects that represents dependencies of an {@code IntelliJComponent} object (that is, modules
+ * This class is a {@link RootPolicy} that builds a list of the names of those {@link OrderEntry}
+ * objects that represents dependencies of an {@link IntelliJComponent} object (that is, modules
  * and non-module-level libraries).
  */
 public class ListDependenciesPolicy extends RootPolicy<List<String>> {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/PostponedRunnable.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/PostponedRunnable.java
@@ -16,7 +16,7 @@ public class PostponedRunnable implements Runnable {
   private Executor executor;
 
   /**
-   * This constructor allows giving a custom {@invokeLater} method, which is useful mostly for
+   * This constructor allows giving a custom {@code invokeLater} method, which is useful mostly for
    * testing purposes.
    */
   public PostponedRunnable(@NotNull Runnable task, @NotNull Executor executor) {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/StateMonitor.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/StateMonitor.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
  * as different integers, semantics of which can be chosen by the client code with the following
  * rules:
  * <ul>
- *   <li>The initial state is {@code INITIAL}</li>.
+ *   <li>The initial state is {@code INITIAL}</li>
  *   <li>All the states greater than or equal to {@code INITIAL} are considered non-error states.
  *   All the states less than or equal to {@code ERROR} are considered error states.</li>
  *   <li>Normally, the state can only increase, that is, on a single change, a new state can never


### PR DESCRIPTION
# Description of the PR

The javadoc is now buildable, although with a 100 warnings

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
