### PR TITLE
Number of tests failed/passed shown for optional assignments

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
@@ -17,7 +17,7 @@ public class FeedbackAvailableNotification extends Notification {
   /**
    * Construct a notification that notifies the user that feedback is available for a submission.
    * The notification contains a link that can be used to open the feedback and the amount of
-   * points the submission got.
+   * points, or the test results the submission got.
    */
   public FeedbackAvailableNotification(@NotNull SubmissionResult submissionResult,
                                        @NotNull Exercise exercise) {
@@ -26,7 +26,7 @@ public class FeedbackAvailableNotification extends Notification {
         getText("notification.FeedbackAvailableNotification.title"),
         getAndReplaceText("notification.FeedbackAvailableNotification.content",
             APlusLocalizationUtil.getEnglishName(exercise.getName()),
-            String.format("%1$d/%2$d", submissionResult.getPoints(), exercise.getMaxPoints())),
+            submissionResult.getFeedbackString()),
         NotificationType.INFORMATION
     );
     super.addAction(new OpenSubmissionNotificationAction(submissionResult));

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -163,7 +163,7 @@ public class PluginSettings implements MainViewModelProvider {
       ProjectManager
           .getInstance()
           .addProjectManagerListener(project, projectManagerListener);
-      return new MainViewModel(exerciseFilterOptions);
+      return new MainViewModel(exerciseFilterOptions, project);
     });
   }
 
@@ -192,7 +192,7 @@ public class PluginSettings implements MainViewModelProvider {
       ProjectManager
           .getInstance()
           .addProjectManagerListener(project, projectManagerListener);
-      return new MainViewModel(exerciseFilterOptions);
+      return new MainViewModel(exerciseFilterOptions, project);
     });
 
     mainViewModelUpdaters.computeIfAbsent(key, projectKey -> {

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -26,6 +26,8 @@ public class Exercise {
 
   private final int maxSubmissions;
 
+  private boolean optionalCompleted = false;
+
   /**
    * Construct an exercise instance with the given parameters.
    *
@@ -122,14 +124,12 @@ public class Exercise {
     return maxSubmissions;
   }
 
-  /**
-   * Returns true if assignment is completed.
-   * @return True if userPoints are the same as maxPoints, otherwise False
-   */
+  public void setCompleted(boolean completed) {
+    this.optionalCompleted = completed;
+  }
+
   public boolean isCompleted() {
-    // Optional assignments are never completed, since they can be filtered separately
-    // and we can't tell from the points whether the submission was correct or not
-    return userPoints == maxPoints && !isOptional();
+    return (userPoints == maxPoints && !isOptional()) || optionalCompleted;
   }
 
   public boolean isOptional() {

--- a/src/main/java/fi/aalto/cs/apluscourses/model/TestResults.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/TestResults.java
@@ -1,0 +1,47 @@
+package fi.aalto.cs.apluscourses.model;
+
+import java.util.HashMap;
+
+public class TestResults {
+
+  private final int succeeded;
+  private final int failed;
+  private final int canceled;
+  private final Long exerciseId;
+  private final Long submissionId;
+
+  /**
+   * Construct an instance with the given test results and IDs.
+   */
+  public TestResults(int succeeded,
+                     int failed,
+                     int canceled,
+                     Long exerciseId,
+                     Long submissionId) {
+    this.succeeded = succeeded;
+    this.failed = failed;
+    this.canceled = canceled;
+    this.exerciseId = exerciseId;
+    this.submissionId = submissionId;
+  }
+
+  /**
+   * Getter for test results.
+   * @return HashMap containing test results.
+   */
+  public HashMap<String, Integer> getTestResults() {
+    HashMap<String, Integer> results = new HashMap<>();
+    results.put("succeeded", this.succeeded);
+    results.put("failed", this.failed);
+    results.put("canceled", this.canceled);
+    return results;
+  }
+
+  public Long getExerciseId() {
+    return exerciseId;
+  }
+
+  public Long getSubmissionId() {
+    return submissionId;
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModel.java
@@ -26,7 +26,10 @@ public class SubmissionResultViewModel extends SelectableNodeViewModel<Submissio
 
   @NotNull
   public String getStatusText() {
-    return getModel().getPoints() + "/" + getModel().getExercise().getMaxPoints() + " points";
+    String points = getModel().getTestResults().isEmpty()
+            ? " points"
+            : "";
+    return getModel().getFeedbackString() + points;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/FeedbackParser.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/FeedbackParser.java
@@ -1,0 +1,73 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FeedbackParser {
+
+  /**
+   * Returns the number in front of testType.
+   * @param feedback Feedback for an assignment, containing test results
+   * @param testType The type of test result (e.g. succeeded)
+   * @return Number of tests for a given type
+   */
+  private static Optional<Integer> testsAmount(String feedback, String testType) {
+    // O1_SPECIFIC
+    String pattern = String.format("\\d+(?= +%s)", testType);
+    Pattern r = Pattern.compile(pattern);
+    Matcher m = r.matcher(feedback);
+    return m.find()
+        ? Optional.of(Integer.parseInt(m.group(0)))
+        : feedback.contains("could not be executed") ? Optional.of(-1) : Optional.empty();
+  }
+
+  /**
+   * Parses the feedback for the test results.
+   * @param feedback Feedback for an assignment, containing test results
+   * @return An optional map, containing test results.
+   */
+  public static Optional<HashMap<String, Integer>> testResultsMap(String feedback) {
+    // O1_SPECIFIC
+    Optional<Integer> succeeded = testsAmount(feedback, "succeeded");
+    Optional<Integer> failed    = testsAmount(feedback, "failed");
+    Optional<Integer> canceled  = testsAmount(feedback, "canceled");
+
+    if (!succeeded.isPresent() || !failed.isPresent() || !canceled.isPresent()) {
+      return Optional.empty();
+    }
+
+    HashMap<String, Integer> results = new HashMap<>();
+    results.put("succeeded", succeeded.get());
+    results.put("failed", failed.get());
+    results.put("canceled", canceled.get());
+
+    return Optional.of(results);
+  }
+
+  /**
+   * Turns feedback results into a string.
+   * @param results Map of the results.
+   * @return A string, telling if the tests passed.
+   */
+  public static String testResultString(HashMap<String, Integer> results) {
+    int succeeded = results.get("succeeded");
+    int failed    = results.get("failed");
+    int canceled  = results.get("canceled");
+
+    if (succeeded == -1) {
+      return PluginResourceBundle.getText("presentation.optionalExercises.failedAll");
+    }
+
+    int totalFailed = failed + canceled;
+    int totalTests  = succeeded + totalFailed;
+
+    String plural = totalFailed == 1 ? "" : "s";
+
+    return succeeded == totalTests
+        ? PluginResourceBundle.getText("presentation.optionalExercises.passed")
+        : PluginResourceBundle.getAndReplaceText(
+                "presentation.optionalExercises.failed", totalFailed, plural);
+  }
+}

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -55,6 +55,10 @@ presentation.exerciseFilterOptions.nonSubmittable=Non-submittable
 presentation.exerciseFilterOptions.Completed=Completed
 presentation.exerciseFilterOptions.Optional=Optional
 
+presentation.optionalExercises.passed=All tests passed
+presentation.optionalExercises.failed={0} test{1} failed
+presentation.optionalExercises.failedAll=Tests failed
+
 # UI
 ## REPL
 ### Java

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
@@ -35,6 +35,9 @@ public class CourseFileManagerTest {
 
   private static final String URL_KEY = "url";
   private static final String LANGUAGE_KEY = "language";
+  private static final String EXERCISES_KEY = "exercises";
+  private static final String SUBMISSIONS_KEY = "submissions";
+  private static final String TEST_RESULTS_KEY = "testResults";
   private static final String MODULES_KEY = "modules";
   private static final String MODULE_ID_KEY = "id";
   private static final String MODULE_DOWNLOADED_AT_KEY = "downloadedAt";
@@ -124,10 +127,23 @@ public class CourseFileManagerTest {
             .put(MODULE_ID_KEY, "abc")
             .put(MODULE_DOWNLOADED_AT_KEY, ZonedDateTime.now())
     );
+    JSONObject exercisesObject = new JSONObject().put("123",
+        new JSONObject().put(SUBMISSIONS_KEY,
+        new JSONObject().put("1",
+        new JSONObject().put(TEST_RESULTS_KEY,
+        new JSONObject()
+              .put("succeeded", 8)
+              .put("failed",    2)
+              .put("canceled",  0)
+          )
+        )
+      )
+    );
     JSONObject jsonObject = new JSONObject()
         .put(URL_KEY, oldUrl)
         .put(LANGUAGE_KEY, oldLanguage)
-        .put(MODULES_KEY, modulesObject);
+        .put(MODULES_KEY, modulesObject)
+        .put(EXERCISES_KEY, exercisesObject);
 
     FileUtils.writeStringToFile(courseFile, jsonObject.toString(), StandardCharsets.UTF_8);
 
@@ -147,6 +163,10 @@ public class CourseFileManagerTest {
         1, manager.getModulesMetadata().size());
     Assert.assertEquals("CourseFileManager#createAndLoad gets the existing modules metadata",
         "abc", manager.getModulesMetadata().get("awesome module").getModuleId());
+    Assert.assertEquals("CourseFileManager#createAndLoad gets the existing exercise test results",
+        3, manager.getTestResults(1L).size());
+    Assert.assertEquals("CourseFileManager#createAndLoad gets the existing exercise test results",
+        8, manager.getTestResults(1L).get("succeeded").intValue());
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/utils/FeedbackParserTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/FeedbackParserTest.java
@@ -1,0 +1,34 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import java.util.HashMap;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FeedbackParserTest {
+
+  @Test
+  public void testFeedbackParser() {
+    String validFeedback1 = "10 succeeded, 0 failed, 0 canceled";
+    String validFeedback2 = "10 succeeded, 5 failed, 0 canceled";
+    String validFeedback3 = "10 succeeded, 1 failed, 0 canceled";
+    String invalidFeedback = "hello";
+
+    Optional<HashMap<String, Integer>> results1 = FeedbackParser.testResultsMap(validFeedback1);
+    Optional<HashMap<String, Integer>> results2 = FeedbackParser.testResultsMap(validFeedback2);
+    Optional<HashMap<String, Integer>> results3 = FeedbackParser.testResultsMap(validFeedback3);
+    Optional<HashMap<String, Integer>> results4 = FeedbackParser.testResultsMap(invalidFeedback);
+    Assert.assertFalse("Invalid feedback is correct", results4.isPresent());
+
+    Assert.assertTrue("Valid feedback 1 is correct",
+            results1.isPresent()
+                    && FeedbackParser.testResultString(results1.get()).equals("All tests passed"));
+    Assert.assertTrue("Valid feedback 2 is correct",
+            results2.isPresent()
+                    && FeedbackParser.testResultString(results2.get()).equals("5 tests failed"));
+    Assert.assertTrue("Valid feedback 3 is correct",
+            results3.isPresent()
+                    && FeedbackParser.testResultString(results3.get()).equals("1 test failed"));
+  }
+
+}


### PR DESCRIPTION
# Description of the PR

Test results for optional assignments are parsed from the feedback and cached to a-plus-project.json. Parsing from the feedback is probably course specific, but I could add support for more courses in the future. If the parsing isn't successful, [0/0 points] is shown instead of [n tests passed/failed]. Amount of tests passed/failed is also shown in the feedback notification

Now when all the tests have passed, the optional assignment is considered completed. It would be good to update the icon in the assignments tree.

More unit tests need to be made, and test caching probably needs to be moved from MainViewModel

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [x] Not yet. I will do it next.
- [ ] Not relevant
