### PR TITLE
Get languages from course configuration

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -17,7 +17,7 @@ import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.ComponentInstaller;
 import fi.aalto.cs.apluscourses.model.ComponentInstallerImpl;
 import fi.aalto.cs.apluscourses.model.Course;
-import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationFileException;
+import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationException;
 import fi.aalto.cs.apluscourses.presentation.CourseProjectViewModel;
 import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogs;
@@ -203,7 +203,7 @@ public class CourseProjectAction extends AnAction {
 
     @NotNull
     Course fromUrl(@NotNull URL courseUrl, @NotNull Project project)
-        throws IOException, MalformedCourseConfigurationFileException;
+        throws IOException, MalformedCourseConfigurationException;
   }
 
   @Nullable
@@ -235,7 +235,7 @@ public class CourseProjectAction extends AnAction {
     } catch (IOException e) {
       notifier.notify(new NetworkErrorNotification(e), project);
       return null;
-    } catch (MalformedCourseConfigurationFileException e) {
+    } catch (MalformedCourseConfigurationException e) {
       logger.error("Malformed course configuration file", e);
       notifier.notify(new CourseConfigurationError(e), project);
       return null;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -11,7 +11,7 @@ import fi.aalto.cs.apluscourses.intellij.notifications.NetworkErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Course;
-import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationFileException;
+import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationException;
 import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
 import java.io.IOException;
 import java.net.URL;
@@ -49,7 +49,7 @@ public class InitializationActivity implements Background {
 
     try {
       Course.fromUrl(courseConfigurationFileUrl, new IntelliJModelFactory(project));
-    } catch (UnexpectedResponseException | MalformedCourseConfigurationFileException e) {
+    } catch (UnexpectedResponseException | MalformedCourseConfigurationException e) {
       logger.error("Error occurred while trying to parse a course configuration file", e);
       notifier.notify(new CourseConfigurationError(e), project);
       return;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -45,6 +45,7 @@ class IntelliJCourse extends Course {
   public IntelliJCourse(@NotNull String id,
                         @NotNull String name,
                         @NotNull String aplusUrl,
+                        @NotNull List<String> languages,
                         @NotNull List<Module> modules,
                         @NotNull List<Library> libraries,
                         @NotNull Map<Long, Map<String, String>> exerciseModules,
@@ -57,12 +58,14 @@ class IntelliJCourse extends Course {
         id,
         name,
         aplusUrl,
+        languages,
         modules,
         libraries,
         exerciseModules,
         resourceUrls,
         autoInstallComponentNames,
-        replInitialCommands);
+        replInitialCommands
+    );
 
     this.project = project;
     this.commonLibraryProvider = commonLibraryProvider;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -37,6 +37,7 @@ public class IntelliJModelFactory implements ModelFactory {
   public Course createCourse(@NotNull String id,
                              @NotNull String name,
                              @NotNull String aplusUrl,
+                             @NotNull List<String> languages,
                              @NotNull List<Module> modules,
                              @NotNull List<Library> libraries,
                              @NotNull Map<Long, Map<String, String>> exerciseModules,
@@ -45,8 +46,8 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull Map<String, String[]> replInitialCommands) {
 
     IntelliJCourse course =
-        new IntelliJCourse(id, name, aplusUrl, modules, libraries, exerciseModules, resourceUrls,
-            autoInstallComponentNames, replInitialCommands, project,
+        new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
+            resourceUrls, autoInstallComponentNames, replInitialCommands, project,
             new CommonLibraryProvider(project));
 
     Component.InitializationCallback componentInitializationCallback =

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -98,7 +98,7 @@ public abstract class Course implements ComponentSource {
 
   @NotNull
   public static Course fromResource(@NotNull String resourceName, @NotNull ModelFactory factory)
-      throws ResourceException, MalformedCourseConfigurationFileException {
+      throws ResourceException, MalformedCourseConfigurationException {
     Reader reader = new InputStreamReader(Resources.DEFAULT.getStream(resourceName));
     return fromConfigurationData(reader, resourceName, factory);
   }
@@ -108,12 +108,12 @@ public abstract class Course implements ComponentSource {
    *
    * @param reader A reader providing a character stream with the course configuration data.
    * @return A course instance containing the information parsed from the configuration data.
-   * @throws MalformedCourseConfigurationFileException If the configuration data is malformed in any
+   * @throws MalformedCourseConfigurationException If the configuration data is malformed in any
    *                                                   way
    */
   @NotNull
   public static Course fromConfigurationData(@NotNull Reader reader, @NotNull ModelFactory factory)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     return fromConfigurationData(reader, "", factory);
   }
 
@@ -124,14 +124,14 @@ public abstract class Course implements ComponentSource {
    * @param sourcePath The path to the source of the reader, which is stored in exceptions thrown
    *                   from this method.
    * @return A course instance containing the information parsed from the configuration data.
-   * @throws MalformedCourseConfigurationFileException If the configuration data is malformed in any
+   * @throws MalformedCourseConfigurationException If the configuration data is malformed in any
    *                                                   way
    */
   @NotNull
   public static Course fromConfigurationData(@NotNull Reader reader,
                                              @NotNull String sourcePath,
                                              @NotNull ModelFactory factory)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     JSONObject jsonObject = getCourseJsonObject(reader, sourcePath);
     String courseId = getCourseId(jsonObject, sourcePath);
     String courseName = getCourseName(jsonObject, sourcePath);
@@ -166,12 +166,12 @@ public abstract class Course implements ComponentSource {
    * @return A course instance containing the information parsed from the course configuration file.
    * @throws IOException                               If an IO error occurs (network connection
    *                                                   issues for an example).
-   * @throws MalformedCourseConfigurationFileException If the course configuration file is malformed
+   * @throws MalformedCourseConfigurationException If the course configuration file is malformed
    *                                                   in any way.
    */
   @NotNull
   public static Course fromUrl(@NotNull URL url, @NotNull ModelFactory modelFactory)
-      throws IOException, MalformedCourseConfigurationFileException {
+      throws IOException, MalformedCourseConfigurationException {
     InputStream inputStream = CoursesClient.fetch(url);
     return Course.fromConfigurationData(
         new InputStreamReader(inputStream), url.toString(), modelFactory);
@@ -271,45 +271,45 @@ public abstract class Course implements ComponentSource {
 
   @NotNull
   private static JSONObject getCourseJsonObject(@NotNull Reader reader, @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     JSONTokener tokenizer = new JSONTokener(reader);
     try {
       return new JSONObject(tokenizer);
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Course configuration file should consist of a valid JSON object", ex);
     }
   }
 
   @NotNull
   private static String getCourseId(@NotNull JSONObject jsonObject, @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     try {
       return jsonObject.getString("id");
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Missing or malformed \"id\" key", ex);
     }
   }
 
   @NotNull
   private static String getCourseName(@NotNull JSONObject jsonObject, @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     try {
       return jsonObject.getString("name");
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Missing or malformed \"name\" key", ex);
     }
   }
 
   @NotNull
   private static String getCourseAPlusUrl(@NotNull JSONObject jsonObject, @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     try {
       return jsonObject.getString("aPlusUrl");
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Missing or malformed \"aPlusUrl\" key", ex);
     }
   }
@@ -317,10 +317,10 @@ public abstract class Course implements ComponentSource {
   @NotNull
   private static List<String> getCourseLanguages(@NotNull JSONObject jsonObject,
                                                  @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     JSONArray languagesJson = jsonObject.optJSONArray("languages");
     if (languagesJson == null) {
-      throw new MalformedCourseConfigurationFileException(
+      throw new MalformedCourseConfigurationException(
           source, "Missing or malformed \"languages\" key", null);
     }
     List<String> languages = new ArrayList<>();
@@ -328,7 +328,7 @@ public abstract class Course implements ComponentSource {
       try {
         languages.add(languagesJson.getString(i));
       } catch (JSONException e) {
-        throw new MalformedCourseConfigurationFileException(
+        throw new MalformedCourseConfigurationException(
             source, "\"languages\" array should contain strings", e);
       }
     }
@@ -339,12 +339,12 @@ public abstract class Course implements ComponentSource {
   private static List<Module> getCourseModules(@NotNull JSONObject jsonObject,
                                                @NotNull String source,
                                                @NotNull ModelFactory factory)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     JSONArray modulesJsonArray;
     try {
       modulesJsonArray = jsonObject.getJSONArray("modules");
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Missing or malformed \"modules\" key", ex);
     }
 
@@ -355,10 +355,10 @@ public abstract class Course implements ComponentSource {
         JSONObject moduleObject = modulesJsonArray.getJSONObject(i);
         modules.add(Module.fromJsonObject(moduleObject, factory));
       } catch (JSONException ex) {
-        throw new MalformedCourseConfigurationFileException(source,
+        throw new MalformedCourseConfigurationException(source,
             "\"modules\" value should be an array of objects containing module information", ex);
       } catch (MalformedURLException ex) {
-        throw new MalformedCourseConfigurationFileException(source,
+        throw new MalformedCourseConfigurationException(source,
             "Malformed URL in module object", ex);
       }
     }
@@ -368,7 +368,7 @@ public abstract class Course implements ComponentSource {
   @NotNull
   private static Map<Long, Map<String, String>> getCourseExerciseModules(@NotNull JSONObject object,
                                                                          @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     Map<Long, Map<String, String>> exerciseModules = new HashMap<>();
     JSONObject exerciseModulesJson = object.optJSONObject("exerciseModules");
     if (exerciseModulesJson == null) {
@@ -388,7 +388,7 @@ public abstract class Course implements ComponentSource {
       }
       return exerciseModules;
     } catch (JSONException e) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Malformed \"exerciseModules\" object", e);
     }
   }
@@ -396,7 +396,7 @@ public abstract class Course implements ComponentSource {
   @NotNull
   private static Map<String, URL> getCourseResourceUrls(@NotNull JSONObject jsonObject,
                                                         @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     Map<String, URL> resourceUrls = new HashMap<>();
     JSONObject resourceUrlsJsonObject = jsonObject.optJSONObject("resources");
     if (resourceUrlsJsonObject == null) {
@@ -408,7 +408,7 @@ public abstract class Course implements ComponentSource {
         URL resourceUrl = new URL(resourceUrlsJsonObject.getString(resourceName));
         resourceUrls.put(resourceName, resourceUrl);
       } catch (JSONException | MalformedURLException ex) {
-        throw new MalformedCourseConfigurationFileException(source,
+        throw new MalformedCourseConfigurationException(source,
             "Expected name-url-pairs in \"resources\" object", ex);
       }
     }
@@ -418,7 +418,7 @@ public abstract class Course implements ComponentSource {
   @NotNull
   private static List<String> getCourseAutoInstallComponentNames(@NotNull JSONObject jsonObject,
                                                                  @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     List<String> autoInstallComponentNames = new ArrayList<>();
     JSONArray autoInstallArray = jsonObject.optJSONArray("autoInstall");
     if (autoInstallArray == null) {
@@ -430,7 +430,7 @@ public abstract class Course implements ComponentSource {
         String autoInstallComponentName = autoInstallArray.getString(i);
         autoInstallComponentNames.add(autoInstallComponentName);
       } catch (JSONException e) {
-        throw new MalformedCourseConfigurationFileException(
+        throw new MalformedCourseConfigurationException(
             source, "Names in \"autoInstall\" array should be course components", e);
       }
     }
@@ -440,7 +440,7 @@ public abstract class Course implements ComponentSource {
   @NotNull
   private static Map<String, String[]> getCourseReplInitialCommands(@NotNull JSONObject jsonObject,
                                                                     @NotNull String source)
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     Map<String, String[]> replInitialCommands = new HashMap<>();
     JSONObject replJson = jsonObject.optJSONObject("repl");
     if (replJson == null) {
@@ -462,7 +462,7 @@ public abstract class Course implements ComponentSource {
         replInitialCommands.put(moduleName, replCommands);
       }
     } catch (JSONException ex) {
-      throw new MalformedCourseConfigurationFileException(source,
+      throw new MalformedCourseConfigurationException(source,
           "Expected moduleName-commands-pairs in \"repl\" object", ex);
     }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/MalformedCourseConfigurationException.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/MalformedCourseConfigurationException.java
@@ -3,13 +3,13 @@ package fi.aalto.cs.apluscourses.model;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class MalformedCourseConfigurationFileException extends Exception {
+public class MalformedCourseConfigurationException extends Exception {
   @NotNull
   private final String pathToConfigurationFile;
 
-  public MalformedCourseConfigurationFileException(@NotNull String pathToConfigurationFile,
-                                                   @NotNull String message,
-                                                   @Nullable Throwable cause) {
+  public MalformedCourseConfigurationException(@NotNull String pathToConfigurationFile,
+                                               @NotNull String message,
+                                               @Nullable Throwable cause) {
     super(message, cause);
     this.pathToConfigurationFile = pathToConfigurationFile;
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -10,6 +10,7 @@ public interface ModelFactory {
   Course createCourse(@NotNull String id,
                       @NotNull String name,
                       @NotNull String aplusUrl,
+                      @NotNull List<String> languages,
                       @NotNull List<Module> modules,
                       @NotNull List<Library> libraries,
                       @NotNull Map<Long, Map<String, String>> exerciseModules,

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModel.java
@@ -60,8 +60,7 @@ public class CourseProjectViewModel {
   }
 
   public String[] getLanguages() {
-    // O1_SPECIFIC: these should come from the course configuration file
-    return new String[] {"fi", "en"};
+    return course.getLanguages().toArray(new String[0]);
   }
 
   public boolean shouldShowCurrentSettings() {

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
@@ -118,6 +118,7 @@ public class CourseProjectActionTest extends BasePlatformTestCase {
         "EMPTY",
         // url
         "http://localhost:1001",
+        Collections.emptyList(),
         //  modules
         Collections.emptyList(),
         //  libraries

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -56,6 +56,7 @@ public class InstallModuleActionTest {
         "id",
         "course",
         "http://localhost:7766",
+        Collections.emptyList(),
         modules,
         //  libraries
         Collections.emptyList(),

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
@@ -35,6 +35,7 @@ public class IntelliJCourseTest {
     CommonLibraryProvider commonLibraryProvider = new CommonLibraryProvider(project);
     IntelliJCourse course = new IntelliJCourse(id, name,
         "http://localhost:1355",
+        Collections.emptyList(),
         //  modules
         Collections.emptyList(),
         //  libraries
@@ -77,6 +78,7 @@ public class IntelliJCourseTest {
     IntelliJCourse course = new IntelliJCourse("cool id",
         "testProject",
         "https://example.com",
+        Collections.emptyList(),
         modules,
         //  libraries
         Collections.emptyList(),
@@ -119,6 +121,7 @@ public class IntelliJCourseTest {
     IntelliJCourse course = new IntelliJCourse("courseId",
         "testtesttest",
         "http://localhost:2000",
+        Collections.emptyList(),
         modules,
         //  libraries
         Collections.emptyList(),
@@ -150,6 +153,7 @@ public class IntelliJCourseTest {
     IntelliJCourse course = new IntelliJCourse("testId",
         "testProject",
         "http://localhost:2200",
+        Collections.emptyList(),
         Stream.of(new ModelExtensions.TestModule(moduleName)).collect(Collectors.toList()),
         //  libraries
         Collections.emptyList(),

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -33,6 +33,7 @@ public class CourseTest {
         "13",
         "Tester Course",
         "http://localhost:2466/",
+        Arrays.asList("se", "en"),
         modules,
         //  libraries
         Collections.emptyList(),
@@ -45,8 +46,12 @@ public class CourseTest {
         "13", course.getId());
     assertEquals("The name of the course should be the same as that given to the constructor",
         "Tester Course", course.getName());
-    assertEquals("The A+ URL of the course shoudl be the same as that given to the constructor",
+    assertEquals("The A+ URL of the course should be the same as that given to the constructor",
         "http://localhost:2466/", course.getHtmlUrl());
+    assertEquals("The languages of the course should be the ones given to the constructor",
+        "se", course.getLanguages().get(0));
+    assertEquals("The languages of the course should be the ones given to the constructor",
+        "en", course.getLanguages().get(1));
     assertEquals("http://localhost:2466/api/v2/", course.getApiUrl());
     assertEquals("The modules of the course should be the same as those given to the constructor",
         module1name, course.getModules().get(0).getName());
@@ -72,6 +77,7 @@ public class CourseTest {
         //  name
         "",
         "http://localhost:2736",
+        Collections.emptyList(),
         //  modules
         Arrays.asList(module1, module2),
         //  libraries
@@ -101,6 +107,7 @@ public class CourseTest {
         //  name
         "",
         "http://localhost:5555",
+        Collections.emptyList(),
         //  modules
         Arrays.asList(module),
         //  libraries
@@ -125,6 +132,7 @@ public class CourseTest {
         "Just some ID",
         "Just some course",
         "http://localhost:1951",
+        Collections.emptyList(),
         //  modules
         Collections.emptyList(),
         //  libraries
@@ -143,6 +151,7 @@ public class CourseTest {
   private static String idJson = "\"id\":\"1238\"";
   private static String nameJson = "\"name\":\"Awesome Course\"";
   private static String urlJson = "\"aPlusUrl\":\"https://example.fi\"";
+  private static String languagesJson = "\"languages\":[\"fi\",\"en\"]";
   private static String modulesJson = "\"modules\":[{\"name\":\"O1Library\",\"url\":"
       + "\"https://wikipedia.org\"},{\"name\":\"GoodStuff\",\"url\":\"https://example.com\"}]";
   private static String exerciseModulesJson = "\"exerciseModules\":{123:{\"en\":\"en_module\"}}";
@@ -155,8 +164,8 @@ public class CourseTest {
   @Test
   public void testFromConfigurationFile() throws MalformedCourseConfigurationFileException {
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
-        + "," + modulesJson + "," + exerciseModulesJson + "," + resourcesJson + ","
-        + autoInstallJson + "," + replInitialCommands + "}");
+        + "," + languagesJson + "," + modulesJson + "," + exerciseModulesJson + "," + resourcesJson
+        + "," + autoInstallJson + "," + replInitialCommands + "}");
     Course course = Course.fromConfigurationData(stringReader, "./path/to/file", MODEL_FACTORY);
     assertEquals("Course should have the same ID as that in the configuration JSON",
         "1238", course.getId());
@@ -164,6 +173,10 @@ public class CourseTest {
         "Awesome Course", course.getName());
     assertEquals("Course should have the same URL as that in the configuration JSON",
         "https://example.fi", course.getHtmlUrl());
+    assertEquals("The course should have the languages of the configuration JSON",
+        "fi", course.getLanguages().get(0));
+    assertEquals("The course should have the languages of the configuration JSON",
+        "en", course.getLanguages().get(1));
     assertEquals("The course should have the modules of the configuration JSON",
         "O1Library", course.getModules().get(0).getName());
     assertEquals("The course should have the modules of the configuration JSON",
@@ -185,32 +198,40 @@ public class CourseTest {
   @Test(expected = MalformedCourseConfigurationFileException.class)
   public void testFromConfigurationFileMissingId()
       throws MalformedCourseConfigurationFileException {
-    StringReader stringReader
-        = new StringReader("{" + nameJson + "," + urlJson + "," + modulesJson + "}");
+    StringReader stringReader = new StringReader(
+        "{" + nameJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
   @Test(expected = MalformedCourseConfigurationFileException.class)
   public void testFromConfigurationFileMissingName()
       throws MalformedCourseConfigurationFileException {
-    StringReader stringReader =
-        new StringReader("{" + idJson + "," + urlJson + "," + modulesJson + "}");
+    StringReader stringReader = new StringReader(
+        "{" + idJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
   @Test(expected = MalformedCourseConfigurationFileException.class)
   public void testFromConfigurationFileMissingUrl()
       throws MalformedCourseConfigurationFileException {
-    StringReader stringReader =
-        new StringReader("{" + idJson + "," + nameJson + "," + modulesJson + "}");
+    StringReader stringReader = new StringReader(
+        "{" + idJson + "," + nameJson + "," + languagesJson + "," + modulesJson + "}");
+    Course.fromConfigurationData(stringReader, MODEL_FACTORY);
+  }
+
+  @Test(expected = MalformedCourseConfigurationFileException.class)
+  public void testFromConfigurationFileMissingLanguages()
+      throws MalformedCourseConfigurationFileException {
+    StringReader stringReader = new StringReader(
+        "{" + idJson + "," + nameJson + "," + urlJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
   @Test(expected = MalformedCourseConfigurationFileException.class)
   public void testFromConfigurationFileMissingModules()
       throws MalformedCourseConfigurationFileException {
-    StringReader stringReader =
-        new StringReader("{" + idJson + "," + nameJson + "," + urlJson + "}");
+    StringReader stringReader = new StringReader(
+        "{" + idJson + "," + nameJson + "," + languagesJson + "," + urlJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
@@ -225,8 +246,8 @@ public class CourseTest {
   public void testFromConfigurationFileWithInvalidModules()
       throws MalformedCourseConfigurationFileException {
     String modules = "\"modules\":[1,2,3,4]";
-    StringReader stringReader
-        = new StringReader("{" + idJson + "," + nameJson + "," + urlJson + "," + modules + "}");
+    StringReader stringReader = new StringReader(
+        "{" + idJson + "," + nameJson + "," + urlJson + "," + languagesJson + "," + modules + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
@@ -235,7 +256,7 @@ public class CourseTest {
       throws MalformedCourseConfigurationFileException {
     String autoInstalls = "\"autoInstall\":[1,2,3,4]";
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
-        + "," + modulesJson + "," + autoInstalls + "}");
+        + "," + languagesJson + "," + modulesJson + "," + autoInstalls + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
@@ -243,8 +264,8 @@ public class CourseTest {
   public void testFromConfigurationWithMalformedReplInitialCommands()
       throws MalformedCourseConfigurationFileException {
     String replJson = "\"repl\": {\"initialCommands\": []}";
-    StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson + ","
-        + replJson + "}");
+    StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
+        + "," + languagesJson + "," + replJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -162,7 +162,7 @@ public class CourseTest {
       + "\"import o1._\",\"import o1.goodstuff._\"]}}";
 
   @Test
-  public void testFromConfigurationFile() throws MalformedCourseConfigurationFileException {
+  public void testFromConfigurationFile() throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + modulesJson + "," + exerciseModulesJson + "," + resourcesJson
         + "," + autoInstallJson + "," + replInitialCommands + "}");
@@ -195,74 +195,74 @@ public class CourseTest {
         "import o1.goodstuff._", course.getReplInitialCommands().get("GoodStuff")[1]);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileMissingId()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader(
         "{" + nameJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileMissingName()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileMissingUrl()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + languagesJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileMissingLanguages()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + urlJson + "," + modulesJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileMissingModules()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + languagesJson + "," + urlJson + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileWithoutJson()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader("random text");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileWithInvalidModules()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     String modules = "\"modules\":[1,2,3,4]";
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + urlJson + "," + languagesJson + "," + modules + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationFileWithInvalidAutoInstalls()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     String autoInstalls = "\"autoInstall\":[1,2,3,4]";
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + modulesJson + "," + autoInstalls + "}");
     Course.fromConfigurationData(stringReader, MODEL_FACTORY);
   }
 
-  @Test(expected = MalformedCourseConfigurationFileException.class)
+  @Test(expected = MalformedCourseConfigurationException.class)
   public void testFromConfigurationWithMalformedReplInitialCommands()
-      throws MalformedCourseConfigurationFileException {
+      throws MalformedCourseConfigurationException {
     String replJson = "\"repl\": {\"initialCommands\": []}";
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + replJson + "}");

--- a/src/test/java/fi/aalto/cs/apluscourses/model/MalformedCourseConfigurationExceptionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/MalformedCourseConfigurationExceptionTest.java
@@ -4,14 +4,14 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-public class MalformedCourseConfigurationFileExceptionTest {
+public class MalformedCourseConfigurationExceptionTest {
 
   @Test
-  public void testCreateMalformedCourseConfigurationFileException() {
+  public void testCreateMalformedCourseConfigurationException() {
     Throwable cause = new Throwable();
     String path = "./path/to/course/configuration/file";
-    MalformedCourseConfigurationFileException exception =
-        new MalformedCourseConfigurationFileException(path, "Awesome message", cause);
+    MalformedCourseConfigurationException exception =
+        new MalformedCourseConfigurationException(path, "Awesome message", cause);
     assertEquals("The cause of the exception should be the one given to the constructor",
         cause, exception.getCause());
     assertEquals("The configuration file path should be the one given to the constructor",

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -90,13 +90,14 @@ public class ModelExtensions {
     public TestCourse(@NotNull String id,
                       @NotNull String name,
                       @NotNull String aplusUrl,
+                      @NotNull List<String> languages,
                       @NotNull List<Module> modules,
                       @NotNull List<Library> libraries,
                       @NotNull Map<Long, Map<String, String>> exerciseModules,
                       @NotNull Map<String, URL> resourceUrls,
                       @NotNull List<String> autoInstallComponentNames,
                       @NotNull Map<String, String[]> replInitialCommands) {
-      super(id, name, aplusUrl, modules, libraries, exerciseModules, resourceUrls,
+      super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls,
           autoInstallComponentNames, replInitialCommands);
       exerciseDataSource = new TestExerciseDataSource();
     }
@@ -118,6 +119,7 @@ public class ModelExtensions {
           id,
           name,
           "https://example.com/",
+          Collections.emptyList(),
           //  modules
           Collections.emptyList(),
           //  libraries
@@ -303,6 +305,7 @@ public class ModelExtensions {
     public Course createCourse(@NotNull String id,
                                @NotNull String name,
                                @NotNull String aplusUrl,
+                               @NotNull List<String> languages,
                                @NotNull List<Module> modules,
                                @NotNull List<Library> libraries,
                                @NotNull Map<Long, Map<String, String>> exerciseModules,
@@ -313,6 +316,7 @@ public class ModelExtensions {
           id,
           name,
           aplusUrl,
+          languages,
           modules,
           libraries,
           exerciseModules,

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -20,7 +20,7 @@ public class CourseProjectViewModelTest {
       "123",
       "NiceCourse",
       "http://localhost:9999",
-      Collections.emptyList(),
+      Collections.singletonList("de"),
       //  modules
       Collections.emptyList(),
       //  libraries
@@ -75,7 +75,7 @@ public class CourseProjectViewModelTest {
   public void testGetLanguages() {
     CourseProjectViewModel courseProjectViewModel
         = new CourseProjectViewModel(emptyCourse, "987");
-    assertArrayEquals(new String[]{"fi", "en"}, courseProjectViewModel.getLanguages());
+    assertArrayEquals(new String[]{"de"}, courseProjectViewModel.getLanguages());
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -20,6 +20,7 @@ public class CourseProjectViewModelTest {
       "123",
       "NiceCourse",
       "http://localhost:9999",
+      Collections.emptyList(),
       //  modules
       Collections.emptyList(),
       //  libraries


### PR DESCRIPTION
# Description of the PR

Languages of a course are now read from the course configuration. This is needed to support multiple courses, as not all courses provide the same languages. This is particularly important when the user selects a language as they turn the project into a course project.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
