### PR TITLE
Control clicking exercise opens submit window

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
@@ -10,8 +10,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.SwingUtilities;
@@ -34,7 +34,8 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
         }
       };
 
-  private final transient HashMap<String, ActionListener> nodeAppliedListeners = new HashMap<>();
+  private final transient Set<ActionListener> ctrlClickListeners = ConcurrentHashMap.newKeySet();
+  private final transient Set<ActionListener> doubleClickListeners = ConcurrentHashMap.newKeySet();
 
   @NotNull
   public static SelectableNodeViewModel<?> getViewModel(Object node) {
@@ -98,12 +99,20 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
     restoreExpandedState(expandedState);
   }
 
-  public void addNodeAppliedListener(String key, ActionListener listener) {
-    nodeAppliedListeners.put(key, listener);
+  public void addDoubleClickListener(ActionListener listener) {
+    doubleClickListeners.add(listener);
   }
 
-  public void removeNodeAppliedListener(String key) {
-    nodeAppliedListeners.remove(key);
+  public void removeDoubleClickListener(ActionListener listener) {
+    doubleClickListeners.remove(listener);
+  }
+
+  public void addCtrlClickListener(ActionListener listener) {
+    ctrlClickListeners.add(listener);
+  }
+
+  public void removeCtrlClickListener(ActionListener listener) {
+    ctrlClickListeners.remove(listener);
   }
 
   @NotNull
@@ -153,10 +162,10 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
     public void mouseClicked(@NotNull MouseEvent e) {
       if (e.getClickCount() == 1 && e.isControlDown() && selectedItem != null) {
         ActionEvent actionEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, null);
-        nodeAppliedListeners.get("submitExercise").actionPerformed(actionEvent);
+        ctrlClickListeners.forEach(listener -> listener.actionPerformed(actionEvent));
       } else if (e.getClickCount() == 2 && selectedItem != null) {
         ActionEvent actionEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, null);
-        nodeAppliedListeners.get("openSubmission").actionPerformed(actionEvent);
+        doubleClickListeners.forEach(listener -> listener.actionPerformed(actionEvent));
       }
     }
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
@@ -10,8 +10,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.SwingUtilities;
@@ -34,7 +34,7 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
         }
       };
 
-  private final transient Set<ActionListener> nodeAppliedListeners = ConcurrentHashMap.newKeySet();
+  private final transient HashMap<String, ActionListener> nodeAppliedListeners = new HashMap<>();
 
   @NotNull
   public static SelectableNodeViewModel<?> getViewModel(Object node) {
@@ -98,12 +98,12 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
     restoreExpandedState(expandedState);
   }
 
-  public void addNodeAppliedListener(ActionListener listener) {
-    nodeAppliedListeners.add(listener);
+  public void addNodeAppliedListener(String key, ActionListener listener) {
+    nodeAppliedListeners.put(key, listener);
   }
 
-  public void removeNodeAppliedListener(ActionListener listener) {
-    nodeAppliedListeners.remove(listener);
+  public void removeNodeAppliedListener(String key) {
+    nodeAppliedListeners.remove(key);
   }
 
   @NotNull
@@ -151,9 +151,12 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
 
     @Override
     public void mouseClicked(@NotNull MouseEvent e) {
-      if (e.getClickCount() == 2 && selectedItem != null) {
+      if (e.getClickCount() == 1 && e.isControlDown() && selectedItem != null) {
         ActionEvent actionEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, null);
-        nodeAppliedListeners.forEach(listener -> listener.actionPerformed(actionEvent));
+        nodeAppliedListeners.get("submitExercise").actionPerformed(actionEvent);
+      } else if (e.getClickCount() == 2 && selectedItem != null) {
+        ActionEvent actionEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, null);
+        nodeAppliedListeners.get("openSubmission").actionPerformed(actionEvent);
       }
     }
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import fi.aalto.cs.apluscourses.intellij.actions.ActionUtil;
 import fi.aalto.cs.apluscourses.intellij.actions.OpenSubmissionAction;
+import fi.aalto.cs.apluscourses.intellij.actions.SubmitExerciseAction;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
 import fi.aalto.cs.apluscourses.ui.GuiObject;
 import fi.aalto.cs.apluscourses.ui.base.TreeView;
@@ -43,7 +44,11 @@ public class ExercisesView {
     exerciseGroupsTree = new TreeView();
     exerciseGroupsTree.setCellRenderer(new ExercisesTreeRenderer());
     exerciseGroupsTree.addNodeAppliedListener(
+        "openSubmission",
         ActionUtil.createOnEventLauncher(OpenSubmissionAction.ACTION_ID, exerciseGroupsTree));
+    exerciseGroupsTree.addNodeAppliedListener(
+        "submitExercise",
+        ActionUtil.createOnEventLauncher(SubmitExerciseAction.ACTION_ID, exerciseGroupsTree));
   }
 
   public TreeView getExerciseGroupsTree() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
@@ -43,11 +43,9 @@ public class ExercisesView {
   private void createUIComponents() {
     exerciseGroupsTree = new TreeView();
     exerciseGroupsTree.setCellRenderer(new ExercisesTreeRenderer());
-    exerciseGroupsTree.addNodeAppliedListener(
-        "openSubmission",
+    exerciseGroupsTree.addDoubleClickListener(
         ActionUtil.createOnEventLauncher(OpenSubmissionAction.ACTION_ID, exerciseGroupsTree));
-    exerciseGroupsTree.addNodeAppliedListener(
-        "submitExercise",
+    exerciseGroupsTree.addCtrlClickListener(
         ActionUtil.createOnEventLauncher(SubmitExerciseAction.ACTION_ID, exerciseGroupsTree));
   }
 


### PR DESCRIPTION
# Description of the PR

Ctrl + left clicking an assignment opens the submission window. Also works when clicking submissions, which I think is fine. Part of #248

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [x] Not yet. I will do it next.
- [ ] Not relevant
