### PR TITLE
Add course selection dialog to course project action

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -123,31 +123,37 @@ Manual testing
 
 **4.4** Open **A+ > Turn project into A+ course project** again.
 
-**4.5** ASSERTION: **Leave IntelliJ settings unchanged** check box is not checked.
+**4.5** ASSERTION: You see a course selection dialog.
 
-**4.6** Check the "leave unchanged" check box.
+**4.6** Select the course O1 and press OK.
 
-**4.7** Select the desired language of assignments submission and click **OK**.
+**4.7** ASSERTION: **Leave IntelliJ settings unchanged** check box is not checked.
+
+**4.8** Check the "leave unchanged" check box.
+
+**4.9** Select the desired language of assignments submission and click **OK**.
 
 ![turn dialog](images/turn_dialog.png)
 
-**4.8** ASSERTION: **O1Library** appears as a module in the project tree.
+**4.10** ASSERTION: **O1Library** appears as a module in the project tree.
 
-**4.9** ASSERTION: **A+ Courses** tool window shows a list of O1 modules in **Modules** list.
+**4.11** ASSERTION: **A+ Courses** tool window shows a list of O1 modules in **Modules** list.
 
-**4.10** ASSERTION: **O1Library** is marked **Installed** in **Modules** list.
+**4.12** ASSERTION: **O1Library** is marked **Installed** in **Modules** list.
 
-**4.11** Once again, navigate to **A+ > Turn project into A+ course project**.
+**4.13** Once again, navigate to **A+ > Turn project into A+ course project**.
 
-**4.12** Leave the settings opt-out check box unchecked, select a language, and click **OK**.
+**4.14** ASSERTION: this time the course selection dialog isn't shown, since the project is already a course project.
 
-**4.13** The screen shows a dialog that tells the IDE will be restarted.
+**4.15** Leave the settings opt-out check box unchecked, select a language, and click **OK**.
 
-**4.14** Click **OK**.
+**4.16** The screen shows a dialog that tells the IDE will be restarted.
 
-**4.15** The IDE restarts.
+**4.17** Click **OK**.
 
-**4.16** ASSERTION: The theme has changed to dark.
+**4.18** The IDE restarts.
+
+**4.19** ASSERTION: The theme has changed to dark.
 
 ### 5 Installing modules
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -76,7 +76,7 @@ public class CourseProjectAction extends AnAction {
       new CourseItemViewModel("O1", "Fall 2020",
           "https://grader.cs.aalto.fi/static/O1_2020/projects/o1_course_config.json"),
       new CourseItemViewModel("Ohjelmointistudio 2 / Programming Studio A", "Spring 2021",
-          "https://grader.cs.aalto.fi/static/studio2_k2021dev/projects/s2_course_config.json")
+          "https://grader.cs.aalto.fi/static/studio2_k2021/projects/s2_course_config.json")
   );
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -18,7 +18,9 @@ import fi.aalto.cs.apluscourses.model.ComponentInstaller;
 import fi.aalto.cs.apluscourses.model.ComponentInstallerImpl;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationException;
+import fi.aalto.cs.apluscourses.presentation.CourseItemViewModel;
 import fi.aalto.cs.apluscourses.presentation.CourseProjectViewModel;
+import fi.aalto.cs.apluscourses.presentation.CourseSelectionViewModel;
 import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogsImpl;
@@ -29,6 +31,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +49,7 @@ public class CourseProjectAction extends AnAction {
   @NotNull
   private final CourseFactory courseFactory;
 
-  private final boolean createCourseFile;
+  private final boolean useCourseFile;
 
   @NotNull
   private final SettingsImporter settingsImporter;
@@ -67,13 +71,21 @@ public class CourseProjectAction extends AnAction {
 
   private final ExecutorService executor;
 
+  // TODO: don't hard code this list
+  private static final List<CourseItemViewModel> AVAILABLE_COURSES = Arrays.asList(
+      new CourseItemViewModel("O1", "Fall 2020",
+          "https://grader.cs.aalto.fi/static/O1_2020/projects/o1_course_config.json"),
+      new CourseItemViewModel("Ohjelmointistudio 2 / Programming Studio A", "Spring 2021",
+          "https://grader.cs.aalto.fi/static/studio2_k2021dev/projects/s2_course_config.json")
+  );
+
   /**
    * Construct a course project action with the given parameters.
    *
    * @param courseFactory    An instance of {@link CourseFactory} that is used to create a course
    *                         instance from a URL.
-   * @param createCourseFile Determines whether a course file is created or not. This is useful
-   *                         mostly for testing purposes.
+   * @param useCourseFile    Determines whether a course file is read/created or not. This is useful
+   *                         only for testing purposes.
    * @param settingsImporter An instance of {@link SettingsImporter} that is used to import IDE and
    *                         project settings.
    * @param installerFactory The factory used to create the component installer. The component
@@ -89,7 +101,7 @@ public class CourseProjectAction extends AnAction {
    * @param notifier         Notification bus.
    */
   public CourseProjectAction(@NotNull CourseFactory courseFactory,
-                             boolean createCourseFile,
+                             boolean useCourseFile,
                              @NotNull SettingsImporter settingsImporter,
                              @NotNull ComponentInstaller.Factory installerFactory,
                              @NotNull PostponedRunnable ideRestarter,
@@ -98,7 +110,7 @@ public class CourseProjectAction extends AnAction {
                              @NotNull Notifier notifier,
                              @NotNull ExecutorService executor) {
     this.courseFactory = courseFactory;
-    this.createCourseFile = createCourseFile;
+    this.useCourseFile = useCourseFile;
     this.settingsImporter = settingsImporter;
     this.installerFactory = installerFactory;
     this.ideRestarter = ideRestarter;
@@ -113,7 +125,7 @@ public class CourseProjectAction extends AnAction {
    */
   public CourseProjectAction() {
     this.courseFactory = (url, project) -> Course.fromUrl(url, new IntelliJModelFactory(project));
-    this.createCourseFile = true;
+    this.useCourseFile = true;
     this.settingsImporter = new SettingsImporter();
     this.installerFactory = new ComponentInstallerImpl.FactoryImpl<>(new SimpleAsyncTaskManager());
     this.dialogs = new CourseProjectActionDialogsImpl();
@@ -135,12 +147,12 @@ public class CourseProjectAction extends AnAction {
       return;
     }
 
-    URL selectedCourseUrl = getSelectedCourseUrl(project);
-    if (selectedCourseUrl == null) {
+    URL courseUrl = tryGetCourseUrl(project);
+    if (courseUrl == null) {
       return;
     }
 
-    Course course = tryGetCourse(project, selectedCourseUrl);
+    Course course = tryGetCourse(project, courseUrl);
     if (course == null) {
       return;
     }
@@ -152,7 +164,7 @@ public class CourseProjectAction extends AnAction {
     }
 
     String language = Objects.requireNonNull(courseProjectViewModel.languageProperty.get());
-    if (!tryCreateCourseFile(project, selectedCourseUrl, language)) {
+    if (!tryCreateCourseFile(project, courseUrl, language)) {
       return;
     }
 
@@ -172,7 +184,7 @@ public class CourseProjectAction extends AnAction {
     Future<Boolean> ideSettingsImported =
         executor.submit(() -> importIdeSettings && tryImportIdeSettings(project, course));
 
-    if (createCourseFile) {
+    if (useCourseFile) {
       // The course file not created in testing.
       PluginSettings.getInstance().createUpdatingMainViewModel(project);
     }
@@ -207,14 +219,21 @@ public class CourseProjectAction extends AnAction {
   }
 
   @Nullable
-  private URL getSelectedCourseUrl(@NotNull Project project) {
-    // TODO: show a dialog with a list of courses and a URL field for custom courses, from which
-    // the user selects a course.
+  private URL tryGetCourseUrl(@NotNull Project project) {
     try {
-      return new URL(PluginSettings.COURSE_CONFIGURATION_FILE_URL);
+      if (useCourseFile && PluginSettings.getInstance().getCourseFileManager(project).load()) {
+        return PluginSettings.getInstance().getCourseFileManager(project).getCourseUrl();
+      }
+
+      CourseSelectionViewModel viewModel = new CourseSelectionViewModel(AVAILABLE_COURSES);
+      boolean cancelled = !dialogs.showCourseSelectionDialog(project, viewModel);
+      return cancelled ? null : new URL(viewModel.selectedCourseUrl.get());
     } catch (MalformedURLException e) {
       // User entered an invalid URL (or the default list has an invalid URL, which would be a bug)
       logger.error("Malformed course configuration file URL", e);
+      notifier.notify(new NetworkErrorNotification(e), project);
+      return null;
+    } catch (IOException e) {
       notifier.notify(new NetworkErrorNotification(e), project);
       return null;
     }
@@ -258,7 +277,7 @@ public class CourseProjectAction extends AnAction {
                                       @NotNull URL courseUrl,
                                       @NotNull String language) {
     try {
-      if (createCourseFile) {
+      if (useCourseFile) {
         PluginSettings
             .getInstance()
             .getCourseFileManager(project)

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -54,9 +54,6 @@ public class PluginSettings implements MainViewModelProvider {
     }
   }
 
-  public static final String COURSE_CONFIGURATION_FILE_URL
-      = "https://grader.cs.hut.fi/static/O1_2020/projects/o1_course_config.json";
-
   public static final String MODULE_REPL_INITIAL_COMMANDS_FILE_NAME
       = ".repl-commands";
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseItemViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseItemViewModel.java
@@ -1,0 +1,35 @@
+package fi.aalto.cs.apluscourses.presentation;
+
+import org.jetbrains.annotations.NotNull;
+
+public class CourseItemViewModel {
+
+  private final String name;
+  private final String semester;
+  private final String url;
+
+  /**
+   * Construct a view model with the given parameters.
+   */
+  public CourseItemViewModel(@NotNull String name, @NotNull String semester, @NotNull String url) {
+    this.name = name;
+    this.semester = semester;
+    this.url = url;
+  }
+
+  @NotNull
+  public String getName() {
+    return name;
+  }
+
+  @NotNull
+  public String getSemester() {
+    return semester;
+  }
+
+  @NotNull
+  public String getUrl() {
+    return url;
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseSelectionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/CourseSelectionViewModel.java
@@ -1,0 +1,37 @@
+package fi.aalto.cs.apluscourses.presentation;
+
+import fi.aalto.cs.apluscourses.utils.observable.ObservableProperty;
+import fi.aalto.cs.apluscourses.utils.observable.ObservableReadWriteProperty;
+import fi.aalto.cs.apluscourses.utils.observable.ValidationError;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+public class CourseSelectionViewModel {
+
+  private List<CourseItemViewModel> courses;
+
+  public final ObservableProperty<String> selectedCourseUrl
+      = new ObservableReadWriteProperty<>("", CourseSelectionViewModel::validateCourseUrl);
+
+  public CourseSelectionViewModel(List<CourseItemViewModel> courses) {
+    this.courses = courses;
+  }
+
+  public CourseItemViewModel[] getCourses() {
+    return courses.toArray(new CourseItemViewModel[0]);
+  }
+
+  private static ValidationError validateCourseUrl(String courseUrl) {
+    if (courseUrl.trim().isEmpty()) {
+      return () -> "Select a course";
+    }
+    try {
+      new URL(courseUrl);
+      return null;
+    } catch (MalformedURLException e) {
+      return () -> "Invalid URL";
+    }
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TextField.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TextField.java
@@ -1,0 +1,27 @@
+package fi.aalto.cs.apluscourses.ui.base;
+
+import fi.aalto.cs.apluscourses.ui.utils.TwoWayBindable;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import javax.swing.JTextField;
+
+/**
+ * A class deriving from {@link JTextField} that works with the {@link TwoWayBindable} class to
+ * reflect its text input to the source property.
+ */
+public class TextField extends JTextField {
+  public final transient TwoWayBindable<TextField, String> textBindable =
+      new TwoWayBindable<>(this, TextField::setText, TextField::getText);
+
+  /**
+   * Construct a TextField.
+   */
+  public TextField() {
+    addKeyListener(new KeyAdapter() {
+      @Override
+      public void keyReleased(KeyEvent e) {
+        textBindable.updateSource();
+      }
+    });
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TextField.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TextField.java
@@ -1,9 +1,9 @@
 package fi.aalto.cs.apluscourses.ui.base;
 
 import fi.aalto.cs.apluscourses.ui.utils.TwoWayBindable;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 /**
  * A class deriving from {@link JTextField} that works with the {@link TwoWayBindable} class to
@@ -17,10 +17,19 @@ public class TextField extends JTextField {
    * Construct a TextField.
    */
   public TextField() {
-    addKeyListener(new KeyAdapter() {
+    getDocument().addDocumentListener(new DocumentListener() {
       @Override
-      public void keyReleased(KeyEvent e) {
+      public void insertUpdate(DocumentEvent documentEvent) {
         textBindable.updateSource();
+      }
+
+      @Override
+      public void removeUpdate(DocumentEvent documentEvent) {
+        textBindable.updateSource();
+      }
+
+      @Override
+      public void changedUpdate(DocumentEvent documentEvent) {
       }
     });
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectActionDialogs.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectActionDialogs.java
@@ -2,12 +2,17 @@ package fi.aalto.cs.apluscourses.ui.courseproject;
 
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.presentation.CourseProjectViewModel;
+import fi.aalto.cs.apluscourses.presentation.CourseSelectionViewModel;
 import org.jetbrains.annotations.NotNull;
 
 public interface CourseProjectActionDialogs {
+
+  boolean showCourseSelectionDialog(@NotNull Project project,
+                                    @NotNull CourseSelectionViewModel courseSelectionViewModel);
 
   boolean showMainDialog(@NotNull Project project,
                          @NotNull CourseProjectViewModel courseProjectViewModel);
 
   boolean showRestartDialog();
+
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectActionDialogsImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectActionDialogsImpl.java
@@ -5,9 +5,17 @@ import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import fi.aalto.cs.apluscourses.presentation.CourseProjectViewModel;
+import fi.aalto.cs.apluscourses.presentation.CourseSelectionViewModel;
 import org.jetbrains.annotations.NotNull;
 
 public class CourseProjectActionDialogsImpl implements CourseProjectActionDialogs {
+
+  @Override
+  public boolean showCourseSelectionDialog(@NotNull Project project,
+                                           @NotNull CourseSelectionViewModel viewModel) {
+    return new CourseSelectionView(project, viewModel).showAndGet();
+  }
+
   @Override
   public boolean showMainDialog(@NotNull Project project,
                                 @NotNull CourseProjectViewModel courseProjectViewModel) {
@@ -24,4 +32,5 @@ public class CourseProjectActionDialogsImpl implements CourseProjectActionDialog
         getText("ui.courseProject.dialogs.showRestartDialog.cancelText"),
         Messages.getQuestionIcon()) == Messages.OK;
   }
+
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseSelectionView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseSelectionView.form
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="fi.aalto.cs.apluscourses.ui.courseproject.CourseSelectionView">
+  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="545" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="c5b1d" class="javax.swing.JLabel" binding="urlFieldLabel">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="b6e01" class="javax.swing.JLabel" binding="courseListLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <minimum-size width="560" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="f2d6d" class="javax.swing.JList" binding="courseList" custom-create="true">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="50"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <vspacer id="bd9da">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="10"/>
+          </grid>
+        </constraints>
+      </vspacer>
+      <component id="8110f" class="javax.swing.JSeparator">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="5f5b" class="javax.swing.JSeparator">
+        <constraints>
+          <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <vspacer id="c15e7">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="10"/>
+          </grid>
+        </constraints>
+      </vspacer>
+      <vspacer id="93ec5">
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="10"/>
+          </grid>
+        </constraints>
+      </vspacer>
+      <vspacer id="828a2">
+        <constraints>
+          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="10"/>
+          </grid>
+        </constraints>
+      </vspacer>
+      <component id="67b11" class="javax.swing.JSeparator">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="8"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="be1ad" class="fi.aalto.cs.apluscourses.ui.base.TextField" binding="urlField" custom-create="true">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseSelectionView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseSelectionView.java
@@ -1,0 +1,117 @@
+package fi.aalto.cs.apluscourses.ui.courseproject;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.ColoredListCellRenderer;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.components.JBList;
+import fi.aalto.cs.apluscourses.presentation.CourseItemViewModel;
+import fi.aalto.cs.apluscourses.presentation.CourseSelectionViewModel;
+import fi.aalto.cs.apluscourses.ui.base.OurDialogWrapper;
+import fi.aalto.cs.apluscourses.ui.base.TextField;
+import fi.aalto.cs.apluscourses.utils.PluginResourceBundle;
+import icons.PluginIcons;
+import java.awt.Font;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class CourseSelectionView extends OurDialogWrapper {
+  private CourseSelectionViewModel viewModel;
+
+  private JPanel basePanel;
+  private JLabel urlFieldLabel;
+  private JLabel courseListLabel;
+  private JList<CourseItemViewModel> courseList;
+  private TextField urlField;
+
+  private static final SimpleTextAttributes NAME_TEXT_ATTRIBUTES
+      = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, null);
+  private static final SimpleTextAttributes SEMESTER_TEXT_ATTRIBUTES
+      = new SimpleTextAttributes(SimpleTextAttributes.STYLE_ITALIC, null);
+
+  /**
+   * Construct a course selection dialog.
+   */
+  public CourseSelectionView(@NotNull Project project,
+                             @NotNull CourseSelectionViewModel viewModel) {
+    super(project);
+    this.viewModel = viewModel;
+    setTitle(PluginResourceBundle.getText("ui.courseProject.courseSelection.title"));
+
+    courseList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    courseList.addListSelectionListener(listSelectionEvent -> {
+      CourseItemViewModel selected = courseList.getSelectedValue();
+      if (selected != null) {
+        viewModel.selectedCourseUrl.set(selected.getUrl());
+      }
+    });
+
+    courseList.setCellRenderer(new ColoredListCellRenderer<CourseItemViewModel>() {
+      @Override
+      protected void customizeCellRenderer(@NotNull JList<? extends CourseItemViewModel> list,
+                                           CourseItemViewModel value,
+                                           int index,
+                                           boolean selected,
+                                           boolean hasFocus) {
+        setIcon(PluginIcons.A_PLUS_EXERCISE_GROUP);
+        append(value.getName(), NAME_TEXT_ATTRIBUTES);
+        append(" " + value.getSemester(), SEMESTER_TEXT_ATTRIBUTES);
+      }
+    });
+
+    courseListLabel.setText(
+        PluginResourceBundle.getText("ui.courseProject.courseSelection.selection"));
+    String fontName = courseListLabel.getFont().getFontName();
+    courseListLabel.setFont(new Font(fontName, Font.BOLD, 20));
+
+    urlFieldLabel.setText(
+        PluginResourceBundle.getText("ui.courseProject.courseSelection.textField"));
+    urlField.addFocusListener(new FocusListener() {
+      @Override
+      public void focusGained(FocusEvent focusEvent) {
+        courseList.clearSelection();
+      }
+
+      @Override
+      public void focusLost(FocusEvent focusEvent) {
+      }
+    });
+    urlField.textBindable.bindToSource(viewModel.selectedCourseUrl);
+
+    registerValidationItem(urlField.textBindable);
+
+    setButtonsAlignment(SwingConstants.CENTER);
+
+    init();
+  }
+
+  @Override
+  protected @NotNull Action[] createActions() {
+    return new Action[]{getOKAction(), getCancelAction()};
+  }
+
+  @Override
+  protected void doOKAction() {
+    urlField.textBindable.updateSource();
+    super.doOKAction();
+  }
+
+  @Override
+  protected @Nullable JComponent createCenterPanel() {
+    return basePanel;
+  }
+
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  private void createUIComponents() {
+    courseList = new JBList<>(viewModel.getCourses());
+    urlField = new TextField();
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/utils/TwoWayBindable.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/utils/TwoWayBindable.java
@@ -18,7 +18,7 @@ public class TwoWayBindable<T extends JComponent, V> extends Bindable<T, V> {
    */
   public synchronized void updateSource() {
     if (sourceProperty != null) {
-      sourceProperty.set(targetGetter.apply(target));
+      sourceProperty.set(targetGetter.apply(target), target);
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/observable/ValidationError.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/observable/ValidationError.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.utils.observable;
 
 import org.jetbrains.annotations.NotNull;
 
+@FunctionalInterface
 public interface ValidationError {
   @NotNull
   String getDescription();

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -117,6 +117,9 @@ ui.courseProject.view=Turn Project Into A+ Project
 ui.courseProject.view.languagePrompt=Select the language you use for the course assignments. (Finnish is recommended if you know Finnish.)
 ui.courseProject.view.languageSelectorDefault=Select language
 ui.courseProjectViewModel.languageNotSelected=Select a language
+ui.courseProject.courseSelection.title=Select Course
+ui.courseProject.courseSelection.selection=Select a course
+ui.courseProject.courseSelection.textField=Configuration URL:
 
 ## UI other
 ### Authentication

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectActionTest.java
@@ -17,6 +17,7 @@ import fi.aalto.cs.apluscourses.model.ComponentInstallerImpl;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.ModelExtensions;
 import fi.aalto.cs.apluscourses.presentation.CourseProjectViewModel;
+import fi.aalto.cs.apluscourses.presentation.CourseSelectionViewModel;
 import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogs;
 import fi.aalto.cs.apluscourses.utils.PostponedRunnable;
@@ -45,6 +46,13 @@ public class CourseProjectActionTest extends BasePlatformTestCase {
       this.doCancel = doCancel;
       this.doRestart = doRestart;
       this.doOptOut = doOptOut;
+    }
+
+    @Override
+    public boolean showCourseSelectionDialog(
+        @NotNull Project project, @NotNull CourseSelectionViewModel courseSelectionViewModel) {
+      courseSelectionViewModel.selectedCourseUrl.set("http://localhost:2358");
+      return !doCancel;
     }
 
     @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseItemViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseItemViewModelTest.java
@@ -1,0 +1,22 @@
+package fi.aalto.cs.apluscourses.presentation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CourseItemViewModelTest {
+
+  @Test
+  public void testCourseItemViewModel() {
+    CourseItemViewModel viewModel = new CourseItemViewModel(
+        "Cool Course", "Summer 1980", "http://www.fi"
+    );
+
+    Assert.assertEquals("The name is the same as the one given to the constructor",
+        "Cool Course", viewModel.getName());
+    Assert.assertEquals("The semester is the same as the one given to the constructor",
+        "Summer 1980", viewModel.getSemester());
+    Assert.assertEquals("The URL is the same as the one given to the constructor",
+        "http://www.fi", viewModel.getUrl());
+  }
+
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseSelectionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseSelectionViewModelTest.java
@@ -1,0 +1,40 @@
+package fi.aalto.cs.apluscourses.presentation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CourseSelectionViewModelTest {
+
+  @Test
+  public void testCourseSelectionViewModel() {
+    CourseSelectionViewModel viewModel = new CourseSelectionViewModel(Arrays.asList(
+        new CourseItemViewModel("A", "A", "http://example.com"),
+        new CourseItemViewModel("B", "B", "http://example.com")
+    ));
+
+    Assert.assertTrue("The URL field is initially empty",
+        viewModel.selectedCourseUrl.get().isEmpty());
+    Assert.assertEquals("The view model contains the given courses",
+        "A", viewModel.getCourses()[0].getName());
+    Assert.assertEquals("The view model contains the given courses",
+        "B", viewModel.getCourses()[1].getName());
+  }
+
+  @Test
+  public void testCourseSelectionValidation() {
+    CourseSelectionViewModel viewModel = new CourseSelectionViewModel(Collections.emptyList());
+
+    Assert.assertNotNull("The initially empty URL field is not accepted",
+        viewModel.selectedCourseUrl.validate());
+
+    viewModel.selectedCourseUrl.set("abc");
+    Assert.assertNotNull("An invalid URL is not accepted",
+        viewModel.selectedCourseUrl.validate());
+
+    viewModel.selectedCourseUrl.set("http://localhost:7777");
+    Assert.assertNull("A valid URL is accepted", viewModel.selectedCourseUrl.validate());
+  }
+
+}


### PR DESCRIPTION
# Description of the PR

This adds a course selection dialog when the user selects "Turn Project Into A+ Course Project". The dialog is only shown if the project isn't already a course project. If the project is a course project already, then the same course will be used again without showing the selection, since it would be undesirable to turn the same project into a course project of a different course.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
