### PR TITLE
Fix (once again) ordering of assignments

### DIFF
--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
@@ -26,17 +26,18 @@ public class ExerciseGroupViewModelTest {
   }
 
   @Test
-  public void testSortsExercises() {
+  public void testSortsExercises1() {
     Exercise first = new Exercise(424, "Assignment 3",
         "http://localhost:1000/w10/ch02/w10_ch02_03/", 0, 0,0);
     Exercise second = new Exercise(325, "Feedback",
-        "http://localhost:2000/w10/ch02/w10_ch02_feedback/", 0, 0, 0);
-    Exercise third = new Exercise(195, "Assignment 1",
-        "http://localhost:3000/w10/ch03/w10_ch03_01/", 0, 0, 0);
-    Exercise fourth = new Exercise(908, "Feedback",
-        "http://localhost:3000/w10/ch03/w10_ch03_feedback/", 0, 0, 0);
-    Exercise fifth = new Exercise(282, "Assignment 1",
-        "http://localhost:3000/w10/ch04/w10_ch04_01/", 0, 0, 0);
+        "http://localhost:1000/w10/ch02/w10_ch02_feedback/", 0, 0, 0);
+    Exercise third = new Exercise(195, "Assignment 9",
+        "http://localhost:1000/w10/ch03/w10_ch03_9/", 0, 0, 0);
+    Exercise fourth = new Exercise(282, "Assignment 10",
+        "http://localhost:1000/w10/ch04/w10_ch03_10/", 0, 0, 0);
+    Exercise fifth = new Exercise(908, "Assignment 1",
+        "http://localhost:1000/w12/ch01/w12_ch01_1/", 0, 0, 0);
+
 
     ExerciseGroup group =
         new ExerciseGroup(5, "", Arrays.asList(third, fifth, first, fourth, second));
@@ -51,7 +52,33 @@ public class ExerciseGroupViewModelTest {
         .toArray(Long[]::new);
 
     Assert.assertArrayEquals("The exercises are sorted correctly",
-        new Long[] {424L, 325L, 195L, 908L, 282L}, ids);
+        new Long[] {424L, 325L, 195L, 282L, 908L}, ids);
+  }
+
+  @Test
+  public void testSortsExercises2() {
+    Exercise first = new Exercise(424, "Assignment 3",
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", 0, 0,0);
+    Exercise second = new Exercise(325, "Feedback",
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_10/", 0, 0, 0);
+    Exercise third = new Exercise(195, "Assignment 9",
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15B_osa01_1/", 0, 0, 0);
+
+
+    ExerciseGroup group =
+        new ExerciseGroup(5, "", Arrays.asList(third, second, first));
+    ExerciseGroupViewModel groupViewModel = new ExerciseGroupViewModel(group);
+    List<ExerciseViewModel> exerciseViewModels = groupViewModel.getChildren().stream()
+        .map(ExerciseViewModel.class::cast).collect(Collectors.toList());
+
+    Long[] ids = exerciseViewModels
+        .stream()
+        .map(ExerciseViewModel::getModel)
+        .map(Exercise::getId)
+        .toArray(Long[]::new);
+
+    Assert.assertArrayEquals("The exercises are sorted correctly",
+        new Long[] {424L, 325L, 195L}, ids);
   }
 
 }


### PR DESCRIPTION
# Description of the PR

The new ordering works well with O1 and Studio 2, and it should work reasonably well with most courses. 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
