### PR TITLE
"Fix" exercise submittability

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -26,6 +26,8 @@ public class Exercise {
 
   private final int maxSubmissions;
 
+  private final boolean submittable;
+
   /**
    * Construct an exercise instance with the given parameters.
    *
@@ -41,13 +43,15 @@ public class Exercise {
                   @NotNull String htmlUrl,
                   int userPoints,
                   int maxPoints,
-                  int maxSubmissions) {
+                  int maxSubmissions,
+                  boolean submittable) {
     this.id = id;
     this.name = name;
     this.htmlUrl = htmlUrl;
     this.userPoints = userPoints;
     this.maxPoints = maxPoints;
     this.maxSubmissions = maxSubmissions;
+    this.submittable = submittable;
   }
 
   /**
@@ -70,7 +74,13 @@ public class Exercise {
     int maxPoints = jsonObject.getInt("max_points");
     int maxSubmissions = jsonObject.getInt("max_submissions");
 
-    Exercise exercise = new Exercise(id, name, htmlUrl, userPoints, maxPoints, maxSubmissions);
+    // TODO: submittability should instead be determined by looking at the individual exercise end
+    // point in the A+ API and seeing if the assignment has files to submit. Take a look at
+    // SubmissionInfo and how it is used in SubmitExerciseAction.
+    boolean isSubmittable = points.isSubmittable(id);
+
+    Exercise exercise
+        = new Exercise(id, name, htmlUrl, userPoints, maxPoints, maxSubmissions, isSubmittable);
 
     List<Long> submissionIds = points.getSubmissions().getOrDefault(id, Collections.emptyList());
     for (int i = 0, length = submissionIds.size(); i < length; i++) {
@@ -120,6 +130,10 @@ public class Exercise {
 
   public int getMaxSubmissions() {
     return maxSubmissions;
+  }
+
+  public boolean isSubmittable() {
+    return submittable;
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Points.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Points.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -20,6 +22,10 @@ public class Points {
   @NotNull
   private final Map<Long, Integer> submissionPoints;
 
+  // TODO: remove
+  @NotNull
+  private Set<Long> submittableExercises;
+
   /**
    * Construct an instance with the given maps.
    * @param submissions      A map of exercise IDs to a list of submission IDs for that exercise.
@@ -34,6 +40,7 @@ public class Points {
     this.submissions = submissions;
     this.exercisePoints = exercisePoints;
     this.submissionPoints = submissionPoints;
+    this.submittableExercises = Collections.emptySet();
   }
 
   @NotNull
@@ -49,6 +56,22 @@ public class Points {
   @NotNull
   public Map<Long, Integer> getSubmissionPoints() {
     return Collections.unmodifiableMap(submissionPoints);
+  }
+
+  /**
+   * DO NOT USE THIS, AS IT IS LIKELY TO BE REMOVED.
+   */
+  @Deprecated
+  public boolean isSubmittable(long exerciseId) {
+    return submittableExercises.contains(exerciseId);
+  }
+
+  /**
+   * DO NOT USE THIS, AS IT IS LIKELY TO BE REMOVED.
+   */
+  @Deprecated
+  public void setSubmittableExercises(@NotNull Set<Long> submittableExercises) {
+    this.submittableExercises = submittableExercises;
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModel.java
@@ -67,6 +67,7 @@ public class MainViewModel {
     ExerciseDataSource dataSource = course.getExerciseDataSource();
     try {
       Points points = dataSource.getPoints(course, auth);
+      points.setSubmittableExercises(course.getExerciseModules().keySet()); // TODO: remove
       List<ExerciseGroup> exerciseGroups = dataSource.getExerciseGroups(course, points, auth);
       exercisesViewModel.set(new ExercisesTreeViewModel(exerciseGroups, exerciseFilterOptions));
     } catch (InvalidAuthenticationException e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -24,11 +24,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> {
    * Returns {@code true} if the exercise is submittable from the plugin, {@code false} otherwise.
    */
   public boolean isSubmittable() {
-    // O1_SPECIFIC
-    String name = getPresentableName();
-    int maxSubmissions = getModel().getMaxSubmissions();
-    return name.length() > "Assignment xx (".length() && !"Assignment 1 (Piazza)".equals(name)
-        && !"Assignment  debugger".equals(name) && (maxSubmissions == 10 || maxSubmissions == 0);
+    return getModel().isSubmittable();
   }
 
   @Override

--- a/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
@@ -75,7 +75,7 @@ public class APlusExerciseDataSourceTest {
     doReturn(response).when(client).fetch("https://example.com/exercises/55/", authentication);
     doReturn(submissionInfo).when(parser).parseSubmissionInfo(response);
 
-    Exercise exercise = new Exercise(55, "myex", "http://localhost:4321", 0, 0, 0);
+    Exercise exercise = new Exercise(55, "myex", "http://localhost:4321", 0, 0, 0, true);
 
     assertSame(submissionInfo, exerciseDataSource.getSubmissionInfo(exercise, authentication));
   }
@@ -89,7 +89,7 @@ public class APlusExerciseDataSourceTest {
         .fetch("https://example.com/exercises/43/submissions/me/", authentication);
     doReturn(submissionHistory).when(parser).parseSubmissionHistory(response);
 
-    Exercise exercise = new Exercise(43, "someex", "https://example.org", 0, 0, 0);
+    Exercise exercise = new Exercise(43, "someex", "https://example.org", 0, 0, 0, true);
 
     assertSame(submissionHistory,
         exerciseDataSource.getSubmissionHistory(exercise, authentication));
@@ -166,7 +166,7 @@ public class APlusExerciseDataSourceTest {
     SubmissionInfo submissionInfo = new SubmissionInfo(
         1, Collections.singletonMap("fi", Arrays.asList(subFile0, subFile1)));
 
-    Exercise exercise = new Exercise(71, "newex", "https://example.com", 0, 0, 0);
+    Exercise exercise = new Exercise(71, "newex", "https://example.com", 0, 0, 0, true);
 
     Group group = new Group(435, new ArrayList<>());
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionActionTest.java
@@ -41,7 +41,7 @@ public class OpenSubmissionActionTest {
    */
   @Before
   public void setUp() {
-    Exercise exercise = new Exercise(223, "TestEx", "http://example.com", 0, 1, 10);
+    Exercise exercise = new Exercise(223, "TestEx", "http://example.com", 0, 1, 10, true);
     submissionResult
         = new SubmissionResult(1, 0, SubmissionResult.Status.GRADED, exercise);
     SubmissionResultViewModel viewModel

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
@@ -37,7 +37,7 @@ public class OpenSubmissionNotificationActionTest {
     event = mock(AnActionEvent.class);
     doReturn(mock(Project.class)).when(event).getProject();
     submissionResult = new SubmissionResult(1, 0, SubmissionResult.Status.GRADED,
-        new Exercise(1, "Ex", "http://example.com", 0, 5, 10));
+        new Exercise(1, "Ex", "http://example.com", 0, 5, 10, true));
     notification = mock(Notification.class);
     notifier = mock(Notifier.class);
     submissionRenderer = mock(UrlRenderer.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -120,7 +120,7 @@ public class SubmitExerciseActionTest {
   @Before
   public void setUp() throws IOException, FileDoesNotExistException {
     exerciseId = 12;
-    exercise = new Exercise(exerciseId, "Test exercise", "http://localhost:10000", 0, 0, 0);
+    exercise = new Exercise(exerciseId, "Test exercise", "http://localhost:10000", 0, 0, 0, true);
     group = new Group(124, Collections.singletonList("Only you"));
     groups = Collections.singletonList(group);
     exerciseGroup = new ExerciseGroup(0, "Test EG", Collections.singletonList(exercise));

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
@@ -15,7 +15,7 @@ public class FeedbackAvailableNotificationTest {
 
   @Test
   public void testFeedbackAvailableNotificationTest() {
-    Exercise exercise = new Exercise(123, "Test Exercise", "https://example.com", 3, 5, 10);
+    Exercise exercise = new Exercise(123, "Test Exercise", "https://example.com", 3, 5, 10, true);
     SubmissionResult result
         = new SubmissionResult(0, 0, SubmissionResult.Status.GRADED, exercise);
     Notification notification = new FeedbackAvailableNotification(result, exercise);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
@@ -22,8 +22,8 @@ public class ExerciseGroupTest {
 
   @Test
   public void testExerciseGroup() {
-    Exercise exercise1 = new Exercise(123, "name1", "https://example.com", 0, 0, 0);
-    Exercise exercise2 = new Exercise(456, "name2", "https://example.org", 0, 0, 0);
+    Exercise exercise1 = new Exercise(123, "name1", "https://example.com", 0, 0, 0, false);
+    Exercise exercise2 = new Exercise(456, "name2", "https://example.org", 0, 0, 0, true);
 
     ExerciseGroup group = new ExerciseGroup(22, "group", Arrays.asList(exercise1, exercise2));
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -20,7 +20,7 @@ public class ExerciseTest {
 
   @Test
   public void testExercise() {
-    Exercise exercise = new Exercise(987, "def", "http://localhost:4444", 13, 15, 10);
+    Exercise exercise = new Exercise(987, "def", "http://localhost:4444", 13, 15, 10, false);
 
     assertEquals("The ID is the same as the one given to the constructor",
         987L, exercise.getId());
@@ -34,6 +34,8 @@ public class ExerciseTest {
         15, exercise.getMaxPoints());
     assertEquals("The maximum submissions are the same as those given to the constructor",
         10, exercise.getMaxSubmissions());
+    assertFalse("The exercise submittability depends on the constructor parameter",
+        exercise.isSubmittable());
   }
 
   @NotNull
@@ -136,9 +138,9 @@ public class ExerciseTest {
 
   @Test
   public void testEquals() {
-    Exercise exercise = new Exercise(7, "oneEx", "http://localhost:1111", 0, 0, 0);
-    Exercise sameExercise = new Exercise(7, "twoEx", "http://localhost:2222", 2, 3, 4);
-    Exercise otherExercise = new Exercise(4, "oneEx", "http://localhost:2222", 3, 2, 1);
+    Exercise exercise = new Exercise(7, "oneEx", "http://localhost:1111", 0, 0, 0, true);
+    Exercise sameExercise = new Exercise(7, "twoEx", "http://localhost:2222", 2, 3, 4, false);
+    Exercise otherExercise = new Exercise(4, "oneEx", "http://localhost:2222", 3, 2, 1, true);
 
     assertEquals(exercise, sameExercise);
     assertEquals(exercise.hashCode(), sameExercise.hashCode());
@@ -148,8 +150,10 @@ public class ExerciseTest {
 
   @Test
   public void testIsCompleted() {
-    Exercise optionalNotSubmitted = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", 0, 0, 0);
-    Exercise optionalSubmitted = new Exercise(2, "optionalSubmitted", "http://localhost:1111", 0, 0, 0);
+    Exercise optionalNotSubmitted
+        = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", 0, 0, 0, true);
+    Exercise optionalSubmitted
+        = new Exercise(2, "optionalSubmitted", "http://localhost:1111", 0, 0, 0, true);
     optionalSubmitted.addSubmissionResult(new SubmissionResult(
             1, 0, SubmissionResult.Status.GRADED, optionalSubmitted));
 
@@ -158,19 +162,21 @@ public class ExerciseTest {
     assertFalse("Optional assignment with submissions isn't completed",
         optionalSubmitted.isCompleted());
 
-    Exercise noSubmissions = new Exercise(3, "noSubmissions", "http://localhost:1111", 0, 5, 10);
-    Exercise failed = new Exercise(4, "failed", "http://localhost:1111", 3, 5, 10);
+    Exercise noSubmissions
+        = new Exercise(3, "noSubmissions", "http://localhost:1111", 0, 5, 10, true);
+    Exercise failed
+        = new Exercise(4, "failed", "http://localhost:1111", 3, 5, 10, true);
     failed.addSubmissionResult(new SubmissionResult(
             1, 3, SubmissionResult.Status.GRADED, failed));
 
-    Exercise completed = new Exercise(5, "completed", "http://localhost:1111", 5, 5, 10);
+    Exercise completed = new Exercise(5, "completed", "http://localhost:1111", 5, 5, 10, true);
     completed.addSubmissionResult(new SubmissionResult(
             1, 5, SubmissionResult.Status.GRADED, completed));
 
 
     assertFalse("Assignment with no submissions isn't completed",
         noSubmissions.isCompleted());
-    assertFalse("Assingment with partial user points isn't completed",
+    assertFalse("Assignment with partial user points isn't completed",
         failed.isCompleted());
     assertTrue("Assignment with full user points is completed",
         completed.isCompleted());
@@ -178,11 +184,11 @@ public class ExerciseTest {
 
   @Test
   public void testIsOptional() {
-    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", 0, 0, 0);
+    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", 0, 0, 0, true);
     assertTrue("Assignment is optional",
             optional.isOptional());
 
-    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", 0, 5, 10);
+    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", 0, 5, 10, true);
     assertFalse("Assignment isn't optional",
         notOptional.isOptional());
   }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
@@ -10,7 +10,7 @@ public class SubmissionResultTest {
 
   @Test
   public void testSubmissionResult() {
-    Exercise exercise = new Exercise(444L, "someEx", "http://example.com/", 15, 20, 10);
+    Exercise exercise = new Exercise(444L, "someEx", "http://example.com/", 15, 20, 10, true);
     SubmissionResult submissionResult
         = new SubmissionResult(123L, 13, SubmissionResult.Status.GRADED, exercise);
     assertEquals("The ID is the same as the one given to the constructor",
@@ -26,7 +26,7 @@ public class SubmissionResultTest {
 
   @Test
   public void testFromJsonObject() {
-    Exercise exercise = new Exercise(555L, "myEx", "https://example.org/", 15, 20, 10);
+    Exercise exercise = new Exercise(555L, "myEx", "https://example.org/", 15, 20, 10, true);
     JSONObject jsonObject = new JSONObject()
         .put("id", 234)
         .put("grade", 30)

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -65,7 +65,7 @@ public class SubmissionStatusUpdaterTest {
         mock(Authentication.class),
         notifier,
         "http://localhost:1000",
-        new Exercise(789, "Cool Exercise Name", "http://example.com", 0, 5, 10),
+        new Exercise(789, "Cool Exercise Name", "http://example.com", 0, 5, 10, true),
         25L, // 0.025 second interval
         0L, // don't increment the interval at all
         10000L // 10 second time limit, which shouldn't be reached
@@ -86,7 +86,7 @@ public class SubmissionStatusUpdaterTest {
         mock(Authentication.class),
         notifier,
         "http://localhost:1000",
-        new Exercise(789, "Cool Exercise Name", "http://example.com", 0, 5, 10),
+        new Exercise(789, "Cool Exercise Name", "http://example.com", 0, 5, 10, true),
         25L, // 0.025 second interval
         0L, // don't increment the interval at all
         200L // 0.2 second time limit, should update at most 8 times

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
@@ -17,7 +17,7 @@ public class SubmissionTest {
 
   @Test
   public void testCreate() {
-    Exercise exercise = new Exercise(85678, "ex", "http://localhost:1000", 0, 0, 0);
+    Exercise exercise = new Exercise(85678, "ex", "http://localhost:1000", 0, 0, 0, true);
     SubmittableFile fileA = new SubmittableFile("keyA", "fileA");
     SubmittableFile fileB = new SubmittableFile("keyB", "fileB");
     String language = "de";

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
@@ -28,15 +28,15 @@ public class ExerciseGroupViewModelTest {
   @Test
   public void testSortsExercises1() {
     Exercise first = new Exercise(424, "Assignment 3",
-        "http://localhost:1000/w10/ch02/w10_ch02_03/", 0, 0,0);
+        "http://localhost:1000/w10/ch02/w10_ch02_03/", 0, 0,0, true);
     Exercise second = new Exercise(325, "Feedback",
-        "http://localhost:1000/w10/ch02/w10_ch02_feedback/", 0, 0, 0);
+        "http://localhost:1000/w10/ch02/w10_ch02_feedback/", 0, 0, 0, true);
     Exercise third = new Exercise(195, "Assignment 9",
-        "http://localhost:1000/w10/ch03/w10_ch03_9/", 0, 0, 0);
+        "http://localhost:1000/w10/ch03/w10_ch03_9/", 0, 0, 0, false);
     Exercise fourth = new Exercise(282, "Assignment 10",
-        "http://localhost:1000/w10/ch04/w10_ch03_10/", 0, 0, 0);
+        "http://localhost:1000/w10/ch04/w10_ch03_10/", 0, 0, 0, false);
     Exercise fifth = new Exercise(908, "Assignment 1",
-        "http://localhost:1000/w12/ch01/w12_ch01_1/", 0, 0, 0);
+        "http://localhost:1000/w12/ch01/w12_ch01_1/", 0, 0, 0, true);
 
 
     ExerciseGroup group =
@@ -58,11 +58,11 @@ public class ExerciseGroupViewModelTest {
   @Test
   public void testSortsExercises2() {
     Exercise first = new Exercise(424, "Assignment 3",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", 0, 0,0);
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", 0, 0,0, false);
     Exercise second = new Exercise(325, "Feedback",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_10/", 0, 0, 0);
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_10/", 0, 0, 0, true);
     Exercise third = new Exercise(195, "Assignment 9",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15B_osa01_1/", 0, 0, 0);
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15B_osa01_1/", 0, 0, 0, true);
 
 
     ExerciseGroup group =

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
@@ -10,10 +10,10 @@ public class ExerciseViewModelTest {
   @Test
   public void testGetPresentableName() {
     Exercise exercise1
-        = new Exercise(123, "|en:Assignment|fi:Tehtava|", "http://localhost:1000", 0, 0,0);
+        = new Exercise(123, "|en:Assignment|fi:Tehtava|", "http://localhost:1000", 0, 0,0, true);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
 
-    Exercise exercise2 = new Exercise(234, "Just a name", "http://localhost:2000", 0, 0, 0);
+    Exercise exercise2 = new Exercise(234, "Just a name", "http://localhost:2000", 0, 0, 0, false);
     ExerciseViewModel viewModel2 = new ExerciseViewModel(exercise2);
 
     Assert.assertEquals("getPresentableName returns the English name of the exercise",
@@ -24,47 +24,28 @@ public class ExerciseViewModelTest {
 
   @Test
   public void testIsSubmittable() {
-    ExerciseViewModel ex1 = new ExerciseViewModel(
-        new Exercise(1, "|en:Assignment 12|fi:Tehtava 12|", "http://localhost:3000", 0, 10, 5)
-    );
-    ExerciseViewModel ex2 = new ExerciseViewModel(
-        new Exercise(2, "|en:Assignment 13 (Test)|fi:Tehtava 13 (Test)|", "http://localhost:4000",
-            0, 20, 10)
-    );
-    ExerciseViewModel ex3 = new ExerciseViewModel(
-        new Exercise(4, "|en:Assignment 14 (Practice)|fi:Tehtava 14 (Harjoitus)",
-            "http://localhost:5000", 0, 0, 0)
-    );
-    ExerciseViewModel ex4 = new ExerciseViewModel(
-        new Exercise(4, "|en:Assignment 1 (Piazza)|fi:Tehtava 1 (Piazza)|", "http://localhost:6000",
-            0, 5, 10)
-    );
-    ExerciseViewModel ex5 = new ExerciseViewModel(
-        new Exercise(4, "|en:Assignment  debugger|fi:Tehtava  debugger|", "http://localhost:6000",
-            0, 0, 0)
-    );
+    Exercise submittable = new Exercise(0, "", "http://abc.org", 0, 0, 0, true);
+    Exercise notSubmittable = new Exercise(0, "", "http://def.org", 0, 0, 0, false);
+    ExerciseViewModel viewModel1 = new ExerciseViewModel(submittable);
+    ExerciseViewModel viewModel2 = new ExerciseViewModel(notSubmittable);
 
-    Assert.assertFalse("An assignment that doesn't have 10 or 0 submissions isn't submittable",
-        ex1.isSubmittable());
-    Assert.assertTrue("An assignment with 10 submissions is submittable", ex2.isSubmittable());
-    Assert.assertTrue("A practice assignment is submittable", ex3.isSubmittable());
-    Assert.assertFalse("The Piazza assignment is not submittable", ex4.isSubmittable());
-    Assert.assertFalse("The debugger assignment is not submittable", ex5.isSubmittable());
+    Assert.assertTrue(viewModel1.isSubmittable());
+    Assert.assertFalse(viewModel2.isSubmittable());
   }
 
   @Test
   public void testGetStatus() {
     String htmlUrl = "http://localhost:6000";
     SubmissionResult.Status resultStatus = SubmissionResult.Status.GRADED;
-    Exercise training = new Exercise(0, "", htmlUrl, 0, 0, 0);
+    Exercise training = new Exercise(0, "", htmlUrl, 0, 0, 0, false);
     training.addSubmissionResult(new SubmissionResult(1L, 0, resultStatus, training));
-    Exercise noPoints = new Exercise(0, "", htmlUrl, 0, 10, 10);
+    Exercise noPoints = new Exercise(0, "", htmlUrl, 0, 10, 10, true);
     noPoints.addSubmissionResult(new SubmissionResult(1L, 0, resultStatus, noPoints));
-    Exercise partialPoints = new Exercise(0, "", htmlUrl, 5, 10, 10);
+    Exercise partialPoints = new Exercise(0, "", htmlUrl, 5, 10, 10, false);
     partialPoints.addSubmissionResult(new SubmissionResult(1L, 5, resultStatus, partialPoints));
-    Exercise fullPoints = new Exercise(0, "", htmlUrl, 10, 10, 10);
+    Exercise fullPoints = new Exercise(0, "", htmlUrl, 10, 10, 10, true);
     fullPoints.addSubmissionResult(new SubmissionResult(1L, 10, resultStatus, fullPoints));
-    Exercise noSubmissions = new Exercise(0, "", htmlUrl, 0, 10, 10);
+    Exercise noSubmissions = new Exercise(0, "", htmlUrl, 0, 10, 10, false);
 
     Assert.assertEquals(ExerciseViewModel.Status.OPTIONAL_PRACTICE,
         new ExerciseViewModel(training).getStatus());
@@ -80,11 +61,11 @@ public class ExerciseViewModelTest {
 
   @Test
   public void testGetStatusText() {
-    Exercise exercise1 = new Exercise(0, "", "http://localhost:1212", 3, 49, 12);
+    Exercise exercise1 = new Exercise(0, "", "http://localhost:1212", 3, 49, 12, false);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
-    Exercise exercise2 = new Exercise(0, "", "http://localhost:2121", 0, 0, 0);
+    Exercise exercise2 = new Exercise(0, "", "http://localhost:2121", 0, 0, 0, false);
     ExerciseViewModel viewModel2 = new ExerciseViewModel(exercise2);
-    Exercise exercise3 = new Exercise(0, "Feedback", "http://localhost:9999", 0, 0, 0);
+    Exercise exercise3 = new Exercise(0, "Feedback", "http://localhost:9999", 0, 0, 0, true);
     ExerciseViewModel viewModel3 = new ExerciseViewModel(exercise3);
 
     Assert.assertEquals("The status text is correct", "0 of 12, 3/49", viewModel1.getStatusText());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
@@ -11,7 +11,7 @@ public class SubmissionResultViewModelTest {
 
   @Test
   public void testSubmissionResultViewModel() {
-    Exercise exercise = new Exercise(0, "", "", 15, 25, 10);
+    Exercise exercise = new Exercise(0, "", "", 15, 25, 10, true);
     SubmissionResult submissionResult
         = new SubmissionResult(123L, 15, SubmissionResult.Status.UNKNOWN, exercise);
     SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 34);

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -46,7 +46,7 @@ public class SubmissionViewModelTest {
 
     SubmissionHistory history = new SubmissionHistory(4);
 
-    Exercise exercise = new Exercise(100, "Exercise", "http://localhost:1000", 0, 0, 0);
+    Exercise exercise = new Exercise(100, "Exercise", "http://localhost:1000", 0, 0, 0, true);
 
     SubmissionViewModel submissionViewModel =
         new SubmissionViewModel(exercise, submissionInfo, history, groups, null, fileMap, language);
@@ -57,7 +57,7 @@ public class SubmissionViewModelTest {
 
   @Test
   public void testSubmissionNumbers() {
-    Exercise exercise = new Exercise(1, "ex", "http://localhost:2000", 0, 0, 5);
+    Exercise exercise = new Exercise(1, "ex", "http://localhost:2000", 0, 0, 5, true);
     SubmissionInfo info = new SubmissionInfo(5, Collections.emptyMap());
 
     SubmissionViewModel submissionViewModel1 = new SubmissionViewModel(exercise, info,
@@ -94,7 +94,7 @@ public class SubmissionViewModelTest {
 
   @Test
   public void testGetFiles() {
-    Exercise exercise = new Exercise(324, "cool", "http://localhost:1324", 0, 0, 0);
+    Exercise exercise = new Exercise(324, "cool", "http://localhost:1324", 0, 0, 0, true);
 
     SubmittableFile englishFile1 = new SubmittableFile("file1", "enFile1");
     SubmittableFile englishFile2 = new SubmittableFile("file2", "enFile2");
@@ -117,7 +117,7 @@ public class SubmissionViewModelTest {
 
   @Test
   public void testDefaultGroup() {
-    Exercise exercise = new Exercise(1000, "wow", "http://www.fi", 0, 0, 0);
+    Exercise exercise = new Exercise(1000, "wow", "http://www.fi", 0, 0, 0, true);
     SubmissionInfo info = new SubmissionInfo(0, Collections.emptyMap());
     SubmissionHistory history = new SubmissionHistory(0);
     Group group = new Group(1, Arrays.asList("Jyrki", "Jorma"));

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
@@ -68,7 +68,7 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
                                               int numberOfSubmissions,
                                               int maxNumberOfSubmissions) {
     return new SubmissionViewModel(
-        new Exercise(1, exerciseName, "http://www.fi", 0, 0, maxNumberOfSubmissions),
+        new Exercise(1, exerciseName, "http://www.fi", 0, 0, maxNumberOfSubmissions, true),
         new SubmissionInfo(maxNumberOfSubmissions,
                 Collections.singletonMap("en", submittableFiles)),
         new SubmissionHistory(numberOfSubmissions),


### PR DESCRIPTION
This fixes #436 by looking at `exerciseModules` from the course configuration to determine whether an assignment is submittable or not. This is only a temporary solution in lieu of a proper solution, that determines submittability from the individual exercise end point in the A+ API. I didn't want to add any course <-> exercise link to the the classes for a temporary solution, so to keep the impact minimal, I have added the information to the `Points` class, which is already available when constructing an `Exercise` object from the JSON corresponding to the exercise.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
