### PR TITLE
Fix right click menu of TreeView on Windows

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
@@ -170,6 +170,12 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
   }
 
   protected class TreeMouseListener extends MouseAdapter {
+    @Override
+    public void mouseReleased(MouseEvent mouseEvent) {
+      if (mouseEvent.isPopupTrigger()) {
+        showPopupMenu(mouseEvent.getPoint());
+      }
+    }
 
     @Override
     public void mousePressed(MouseEvent mouseEvent) {


### PR DESCRIPTION
# Description of the PR

+ Fixed by listening for mouse release

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
