### PR TITLE
Hide notifications

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationAction.java
@@ -1,6 +1,5 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
@@ -8,6 +7,7 @@ import fi.aalto.cs.apluscourses.dal.APlusTokenAuthentication;
 import fi.aalto.cs.apluscourses.dal.PasswordStorage;
 import fi.aalto.cs.apluscourses.intellij.dal.IntelliJPasswordStorage;
 import fi.aalto.cs.apluscourses.intellij.notifications.ApiTokenNotSetNotification;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.Dialogs;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
@@ -42,7 +42,7 @@ public class APlusAuthenticationAction extends DumbAwareAction {
     this(PluginSettings.getInstance(),
         Dialogs.DEFAULT,
         IntelliJPasswordStorage::new,
-        Notifications.Bus::notify);
+        new DefaultNotifier());
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -1,7 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
 import com.intellij.concurrency.JobScheduler;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -11,6 +10,7 @@ import fi.aalto.cs.apluscourses.intellij.model.IntelliJModelFactory;
 import fi.aalto.cs.apluscourses.intellij.model.SettingsImporter;
 import fi.aalto.cs.apluscourses.intellij.notifications.CourseConfigurationError;
 import fi.aalto.cs.apluscourses.intellij.notifications.CourseFileError;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.NetworkErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
@@ -135,7 +135,7 @@ public class CourseProjectAction extends AnAction {
       }
     });
     this.installerDialogsFactory = InstallerDialogs::new;
-    this.notifier = Notifications.Bus::notify;
+    this.notifier = new DefaultNotifier();
     this.executor = JobScheduler.getScheduler();
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ExportModuleAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ExportModuleAction.java
@@ -2,13 +2,13 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import fi.aalto.cs.apluscourses.intellij.model.ProjectModuleSource;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.IoErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.Dialogs;
@@ -62,7 +62,7 @@ public class ExportModuleAction extends AnAction {
         project -> project.getProjectFile().getParent().getParent(),
         (zip, directory) -> new ZipFile(zip.toString()).addFolder(directory.toFile()),
         Dialogs.DEFAULT,
-        Notifications.Bus::notify
+        new DefaultNotifier()
     );
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionAction.java
@@ -1,8 +1,8 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.SubmissionRenderingErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
@@ -44,7 +44,7 @@ public class OpenSubmissionAction extends DumbAwareAction {
     this(
         PluginSettings.getInstance(),
         new UrlRenderer(),
-        Notifications.Bus::notify
+        new DefaultNotifier()
     );
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationAction.java
@@ -2,8 +2,8 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.SubmissionRenderingErrorNotification;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
@@ -23,7 +23,7 @@ public class OpenSubmissionNotificationAction extends NotificationAction {
   private final Notifier notifier;
 
   public OpenSubmissionNotificationAction(@NotNull SubmissionResult submissionResult) {
-    this(submissionResult, new UrlRenderer(), Notifications.Bus::notify);
+    this(submissionResult, new UrlRenderer(), new DefaultNotifier());
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -5,7 +5,6 @@ import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 import static icons.PluginIcons.ACCENT_COLOR;
 
 import com.intellij.history.LocalHistory;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -13,6 +12,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.intellij.model.ProjectModuleSource;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.ExerciseNotSelectedNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.MissingFileNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.MissingModuleNotification;
@@ -87,7 +87,7 @@ public class SubmitExerciseAction extends AnAction {
         VfsUtil::findFileInDirectory,
         new ProjectModuleSource(),
         Dialogs.DEFAULT,
-        Notifications.Bus::notify,
+        new DefaultNotifier(),
         LocalHistory.getInstance()::putSystemLabel,
         FileDocumentManager.getInstance()::saveAllDocuments
     );
@@ -159,7 +159,7 @@ public class SubmitExerciseAction extends AnAction {
     ExerciseViewModel selectedExercise = (ExerciseViewModel) selection.getLevel(2);
     ExerciseGroupViewModel selectedExerciseGroup = (ExerciseGroupViewModel) selection.getLevel(1);
     if (selectedExercise == null || selectedExerciseGroup == null) {
-      notifier.notify(new ExerciseNotSelectedNotification(), project);
+      notifier.notifyAndHide(new ExerciseNotSelectedNotification(), project);
       return;
     }
 
@@ -245,7 +245,7 @@ public class SubmitExerciseAction extends AnAction {
     new SubmissionStatusUpdater(
         project, exerciseDataSource, authentication, submissionUrl, selectedExercise.getModel()
     ).start();
-    notifier.notify(new SubmissionSentNotification(), project);
+    notifier.notifyAndHide(new SubmissionSentNotification(), project);
 
     String tag = getAndReplaceText("ui.localHistory.submission.tag",
         selectedExerciseGroup.getPresentableName(),

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -2,11 +2,11 @@ package fi.aalto.cs.apluscourses.intellij.activities;
 
 import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.MODULE_REPL_INITIAL_COMMANDS_FILE_NAME;
 
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity.Background;
 import fi.aalto.cs.apluscourses.intellij.model.IntelliJModelFactory;
 import fi.aalto.cs.apluscourses.intellij.notifications.CourseConfigurationError;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.NetworkErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
@@ -29,7 +29,7 @@ public class InitializationActivity implements Background {
   private final Notifier notifier;
 
   public InitializationActivity() {
-    this(Notifications.Bus::notify);
+    this(new DefaultNotifier());
   }
 
   public InitializationActivity(@NotNull Notifier notifier) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/DefaultNotifier.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/DefaultNotifier.java
@@ -1,0 +1,17 @@
+package fi.aalto.cs.apluscourses.intellij.notifications;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DefaultNotifier implements Notifier {
+  public void notify(@NotNull Notification notification, @Nullable Project project) {
+    Notifications.Bus.notify(notification, project);
+  }
+
+  public void notifyAndHide(@NotNull Notification notification, @Nullable Project project) {
+    NotificationUtil.notifyAndHide(notification, project);
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/NotificationUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/NotificationUtil.java
@@ -3,17 +3,16 @@ package fi.aalto.cs.apluscourses.intellij.notifications;
 import com.intellij.notification.Notification;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
+import java.util.concurrent.Executors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
+public class NotificationUtil {
+  private static final Logger logger = LoggerFactory.getLogger(NotificationUtil.class);
 
-public class NotifyAndHide {
-  private static final Logger logger = LoggerFactory.getLogger(NotifyAndHide.class);
-
-  private NotifyAndHide() {
+  private NotificationUtil() {
   }
 
   /**
@@ -23,6 +22,7 @@ public class NotifyAndHide {
    * @param project      The Project where the Notification is shown.
    */
   public static void notifyAndHide(@NotNull Notification notification, @Nullable Project project) {
+    // IntelliJ implementation of notifyAndHide is missing the project parameter from notify
     Notifications.Bus.notify(notification, project);
     Executors.newSingleThreadExecutor().submit(() -> {
       try {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
@@ -1,36 +1,11 @@
 package fi.aalto.cs.apluscourses.intellij.notifications;
 
 import com.intellij.notification.Notification;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
-import java.util.concurrent.Executors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @FunctionalInterface
 public interface Notifier {
   void notify(@NotNull Notification notification, @Nullable Project project);
-
-  Logger logger = LoggerFactory.getLogger(Notifier.class);
-
-  /**
-   * Shows a notification and hides it after 6 seconds.
-   * @param notification The Notification to be shown.
-   * @param project The Project where the Notification is shown.
-   */
-  static void notifyAndHide(@NotNull Notification notification, @Nullable Project project) {
-    Notifications.Bus.notify(notification, project);
-    Executors.newSingleThreadExecutor().submit(() -> {
-      try {
-        Thread.sleep(6000);
-        notification.expire();
-      } catch (InterruptedException e) {
-        logger.error("Notification timeout interrupted", e);
-        Thread.currentThread().interrupt();
-      }
-      return null;
-    });
-  }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
@@ -5,7 +5,8 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@FunctionalInterface
 public interface Notifier {
   void notify(@NotNull Notification notification, @Nullable Project project);
+
+  void notifyAndHide(@NotNull Notification notification, @Nullable Project project);
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/Notifier.java
@@ -1,11 +1,36 @@
 package fi.aalto.cs.apluscourses.intellij.notifications;
 
 import com.intellij.notification.Notification;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
+import java.util.concurrent.Executors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @FunctionalInterface
 public interface Notifier {
   void notify(@NotNull Notification notification, @Nullable Project project);
+
+  Logger logger = LoggerFactory.getLogger(Notifier.class);
+
+  /**
+   * Shows a notification and hides it after 6 seconds.
+   * @param notification The Notification to be shown.
+   * @param project The Project where the Notification is shown.
+   */
+  static void notifyAndHide(@NotNull Notification notification, @Nullable Project project) {
+    Notifications.Bus.notify(notification, project);
+    Executors.newSingleThreadExecutor().submit(() -> {
+      try {
+        Thread.sleep(6000);
+        notification.expire();
+      } catch (InterruptedException e) {
+        logger.error("Notification timeout interrupted", e);
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    });
+  }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/NotifyAndHide.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/NotifyAndHide.java
@@ -1,0 +1,38 @@
+package fi.aalto.cs.apluscourses.intellij.notifications;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+
+public class NotifyAndHide {
+  private static final Logger logger = LoggerFactory.getLogger(NotifyAndHide.class);
+
+  private NotifyAndHide() {
+  }
+
+  /**
+   * Shows a notification and hides it after 6 seconds.
+   *
+   * @param notification The Notification to be shown.
+   * @param project      The Project where the Notification is shown.
+   */
+  public static void notifyAndHide(@NotNull Notification notification, @Nullable Project project) {
+    Notifications.Bus.notify(notification, project);
+    Executors.newSingleThreadExecutor().submit(() -> {
+      try {
+        Thread.sleep(6000);
+        notification.expire();
+      } catch (InterruptedException e) {
+        logger.error("Notification timeout interrupted", e);
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    });
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -6,13 +6,13 @@ import static fi.aalto.cs.apluscourses.intellij.services.PluginSettings.LocalIde
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import fi.aalto.cs.apluscourses.intellij.dal.IntelliJPasswordStorage;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.utils.CourseFileManager;
 import fi.aalto.cs.apluscourses.intellij.utils.IntelliJFilterOption;
 import fi.aalto.cs.apluscourses.presentation.MainViewModel;
@@ -195,7 +195,7 @@ public class PluginSettings implements MainViewModelProvider {
     mainViewModelUpdaters.computeIfAbsent(key, projectKey -> {
       MainViewModelUpdater mainViewModelUpdater = new MainViewModelUpdater(
           mainViewModel, project, MAIN_VIEW_MODEL_UPDATE_INTERVAL,
-          Notifications.Bus::notify, IntelliJPasswordStorage::new);
+          new DefaultNotifier(), IntelliJPasswordStorage::new);
       mainViewModelUpdater.start();
       return mainViewModelUpdater;
     });

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -1,9 +1,9 @@
 package fi.aalto.cs.apluscourses.model;
 
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
+import fi.aalto.cs.apluscourses.intellij.notifications.NotifyAndHide;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +85,7 @@ public class SubmissionStatusUpdater {
         project,
         dataSource,
         authentication,
-        Notifications.Bus::notify,
+        NotifyAndHide::notifyAndHide,
         submissionUrl,
         exercise,
         DEFAULT_INTERVAL,
@@ -110,7 +110,7 @@ public class SubmissionStatusUpdater {
           submissionResult =
               dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
           if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
-            Notifier.notifyAndHide(new FeedbackAvailableNotification(submissionResult, exercise), project);
+            notifier.notify(new FeedbackAvailableNotification(submissionResult, exercise), project);
             PluginSettings.getInstance().updateMainViewModel(project);
             return;
           }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -110,7 +110,7 @@ public class SubmissionStatusUpdater {
           submissionResult =
               dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
           if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
-            notifier.notify(new FeedbackAvailableNotification(submissionResult, exercise), project);
+            Notifier.notifyAndHide(new FeedbackAvailableNotification(submissionResult, exercise), project);
             PluginSettings.getInstance().updateMainViewModel(project);
             return;
           }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -1,9 +1,9 @@
 package fi.aalto.cs.apluscourses.model;
 
 import com.intellij.openapi.project.Project;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
-import fi.aalto.cs.apluscourses.intellij.notifications.NotifyAndHide;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +85,7 @@ public class SubmissionStatusUpdater {
         project,
         dataSource,
         authentication,
-        NotifyAndHide::notifyAndHide,
+        new DefaultNotifier(),
         submissionUrl,
         exercise,
         DEFAULT_INTERVAL,
@@ -110,7 +110,8 @@ public class SubmissionStatusUpdater {
           submissionResult =
               dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
           if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
-            notifier.notify(new FeedbackAvailableNotification(submissionResult, exercise), project);
+            notifier.notifyAndHide(
+                new FeedbackAvailableNotification(submissionResult, exercise), project);
             PluginSettings.getInstance().updateMainViewModel(project);
             return;
           }

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModelUpdater.java
@@ -195,7 +195,7 @@ public class MainViewModelUpdater {
     List<Module> updatableModules = filterOldUpdatableModules(newCourse.getUpdatableModules());
     if (!updatableModules.isEmpty()) {
       newModulesVersionsNotification = new NewModulesVersionsNotification(updatableModules);
-      notifier.notify(newModulesVersionsNotification, project);
+      notifier.notifyAndHide(newModulesVersionsNotification, project);
     }
   }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -237,7 +237,7 @@ public class SubmitExerciseActionTest {
     ArgumentCaptor<SubmissionSentNotification> notificationArg =
         ArgumentCaptor.forClass(SubmissionSentNotification.class);
 
-    verify(notifier).notify(notificationArg.capture(), eq(project));
+    verify(notifier).notifyAndHide(notificationArg.capture(), eq(project));
     verify(tagger).putSystemLabel(any(), anyString(), anyInt());
     verify(documentSaver).saveAllDocuments();
   }
@@ -251,7 +251,7 @@ public class SubmitExerciseActionTest {
     ArgumentCaptor<ExerciseNotSelectedNotification> notification
         = ArgumentCaptor.forClass(ExerciseNotSelectedNotification.class);
 
-    verify(notifier).notify(notification.capture(), eq(project));
+    verify(notifier).notifyAndHide(notification.capture(), eq(project));
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -74,7 +74,7 @@ public class SubmissionStatusUpdaterTest {
 
     assertEquals("The submission results are not fetched anymore after feedback is available",
         3, dataSource.getSubmissionResultFetchCount());
-    verify(notifier).notify(any(FeedbackAvailableNotification.class), same(project));
+    verify(notifier).notifyAndHide(any(FeedbackAvailableNotification.class), same(project));
   }
 
   @Test


### PR DESCRIPTION
# Description of the PR

Automatic hiding for notifications. Closes #368

Maybe I'm hiding too many notifications. Error notifications get hidden by default so they don't need to be changed

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
