### PR TITLE
Fix assignment tree double click

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
@@ -12,6 +12,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -186,7 +188,10 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
 
     @Override
     public void mouseClicked(@NotNull MouseEvent e) {
-      if (e.getClickCount() == 2 && viewModel.getSelectedItem() != null) {
+      // Double clicking items with no children
+      if (e.getClickCount() == 2
+          && Optional.ofNullable(viewModel.getSelectedItem())
+          .map(SelectableNodeViewModel::getChildren).map(List::isEmpty).orElse(false)) {
         ActionEvent actionEvent = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, null);
         nodeAppliedListeners.forEach(listener -> listener.actionPerformed(actionEvent));
       }


### PR DESCRIPTION
# Description of the PR

Because of #494 items that should get expanded when double clicking in the assignment tree also get opened in the browser. Now only items with no children get opened

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](/TESTING.md) or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
