### PR TITLE
Automated UI testing: project creation #495

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,6 @@ repositories {
     maven { url = "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
 }
 
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'net.lingala.zip4j', name: 'zip4j', version: '2.6.3'
@@ -54,6 +50,12 @@ intellij {
 sourceSets {
     e2e {
         kotlin.srcDir "$projectDir/src/e2e/kotlin"
+    }
+}
+
+compileE2eKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 
@@ -116,4 +118,11 @@ sonarqube {
         property 'sonar.java.libraries', 'build/libs'
         property 'sonar.coverage.exclusions', 'src/test/**/*'
     }
+}
+
+runIdeForUiTests {
+    systemProperty 'robot-server.port', '8082'
+    systemProperty 'jb.consents.confirmation.enabled', 'false'
+    systemProperty 'jb.privacy.policy.text', '<!--999.999-->'
+    systemProperty 'ide.show.tips.on.startup.default.value', 'false'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'scala'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
     id 'checkstyle'
     id 'com.github.alisiikh.scalastyle' version '3.3.1'
     id 'org.jetbrains.intellij' version '0.4.21'
@@ -12,9 +13,17 @@ version '2.0'
 
 sourceCompatibility = 1.8
 
+def remoteRobotVersion = '0.10.3'
+def fixturesVersion = "1.1.18"
+
 repositories {
     mavenCentral()
     jcenter()
+    maven { url = "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
 }
 
 dependencies {
@@ -31,12 +40,26 @@ dependencies {
     testCompile('io.rest-assured:rest-assured:4.2.0') {
         exclude group:'org.codehaus.groovy', module: 'groovy-xml'
     }
+    testImplementation("com.intellij.remoterobot:remote-robot:$remoteRobotVersion")
+    testImplementation("com.intellij.remoterobot:remote-fixtures:$fixturesVersion")
 }
 
 intellij {
     //  this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
     version '2020.3'
     plugins = ['java', 'org.intellij.scala:2020.3.16']
+    downloadRobotServerPlugin.version = remoteRobotVersion
+}
+
+sourceSets {
+    e2e {
+        kotlin.srcDir "$projectDir/src/e2e/kotlin"
+    }
+}
+
+configurations {
+    e2eImplementation.extendsFrom testImplementation
+    e2eRuntime.extendsFrom testRuntime
 }
 
 publishPlugin {
@@ -58,6 +81,11 @@ scalastyle {
             skip = true
         }
     }
+}
+
+task uiTest(type: Test) {
+    testClassesDirs = sourceSets.e2e.output.classesDirs
+    classpath = sourceSets.e2e.runtimeClasspath
 }
 
 task gatherBuildInfo(dependsOn: processResources) {

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
@@ -16,7 +16,6 @@ class PlaceholderTest {
   fun simpleTest() = uiTest {
     with(CommonSteps(this)) {
       createProject()
-      closeTipOfTheDay()
       downloadAndSetOpenJdk11()
     }
     with(ideFrame()) {

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
@@ -1,0 +1,26 @@
+package fi.aalto.cs.apluscourses.e2e
+
+import fi.aalto.cs.apluscourses.e2e.fixtures.*
+import fi.aalto.cs.apluscourses.e2e.steps.CommonSteps
+import fi.aalto.cs.apluscourses.e2e.utils.StepLoggerInitializer
+import fi.aalto.cs.apluscourses.e2e.utils.uiTest
+import org.junit.Assert.*
+import org.junit.Test
+
+class PlaceholderTest {
+  init {
+    StepLoggerInitializer.init()
+  }
+
+  @Test
+  fun simpleTest() = uiTest {
+    with(CommonSteps(this)) {
+      createProject()
+      closeTipOfTheDay()
+      downloadAndSetOpenJdk11()
+    }
+    with(ideFrame()) {
+      assertNotNull(menu().select("A+"))
+    }
+  }
+}

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/PlaceholderTest.kt
@@ -14,10 +14,7 @@ class PlaceholderTest {
 
   @Test
   fun simpleTest() = uiTest {
-    with(CommonSteps(this)) {
-      createProject()
-      downloadAndSetOpenJdk11()
-    }
+    CommonSteps(this).createProject()
     with(ideFrame()) {
       assertNotNull(menu().select("A+"))
     }

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -45,11 +45,11 @@ class WelcomeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteCompo
 @DefaultXpath("IdeFrameImpl type", "//div[@class='IdeFrameImpl']")
 class IdeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : CommonContainerFixture(remoteRobot, remoteComponent) {
-  fun menu() = find(MenuItemFixture::class.java)
+  fun menu() = find(MenuItemFixture::class.java,
+    LocatorBuilder().withClass(JMenuBar::class.java).build())
 }
 
 @FixtureName("Menu Item")
-@DefaultXpath("MenuFrameHeader type", "//div[@class='MenuFrameHeader']")
 class MenuItemFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent) {
   fun item(text: String) = find(MenuItemFixture::class.java,

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -1,0 +1,80 @@
+package fi.aalto.cs.apluscourses.e2e.fixtures
+
+import com.intellij.remoterobot.RemoteRobot
+import com.intellij.remoterobot.SearchContext
+import com.intellij.remoterobot.data.RemoteComponent
+import com.intellij.remoterobot.fixtures.ComponentFixture
+import com.intellij.remoterobot.fixtures.ContainerFixture
+import com.intellij.remoterobot.fixtures.DefaultXpath
+import com.intellij.remoterobot.fixtures.FixtureName
+import com.intellij.remoterobot.search.locators.byXpath
+import java.time.Duration
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JDialog
+import javax.swing.JMenuItem
+
+fun RemoteRobot.welcomeFrame() = find(WelcomeFrame::class.java, Duration.ofSeconds(60))
+
+fun RemoteRobot.ideFrame() = find(IdeFrame::class.java, Duration.ofSeconds(20))
+
+fun <T> Class<T>.toXPathExp(): String = "@javaclass='$name' or contains(@classhierarchy, '$name')"
+
+fun <T> byAttributeAndSwingClass(attr : String, value : String, clazz : Class<T>) =
+    byXpath("//div[@$attr='$value' and (${clazz.toXPathExp()})]")
+
+fun SearchContext.button(name: String) = find(Button::class.java,
+    byAttributeAndSwingClass("accessiblename", name, JButton::class.java))
+
+fun SearchContext.comboBox(name: String) = find(ComboBox::class.java,
+    byAttributeAndSwingClass("accessiblename", name, JComboBox::class.java))
+
+fun SearchContext.dialog(title: String, timeout : Duration = Duration.ofSeconds(5)) =
+    find(Dialog::class.java, byAttributeAndSwingClass("title", title, JDialog::class.java), timeout)
+
+fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindow::class.java)
+
+@FixtureName("Welcome Frame")
+@DefaultXpath(by = "FlatWelcomeFrame type", xpath = "//div[@class='FlatWelcomeFrame']")
+class WelcomeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ContainerFixture(remoteRobot, remoteComponent)
+
+@FixtureName("IDE Frame")
+@DefaultXpath("IdeFrameImpl type", "//div[@class='IdeFrameImpl']")
+class IdeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ContainerFixture(remoteRobot, remoteComponent) {
+  fun menu() = find(MenuItem::class.java)
+}
+
+@FixtureName("Button")
+class Button(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ComponentFixture(remoteRobot, remoteComponent)
+
+@FixtureName("Menu Item")
+@DefaultXpath("MenuFrameHeader type", "//div[@class='MenuFrameHeader']")
+class MenuItem(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ContainerFixture(remoteRobot, remoteComponent) {
+  fun item(text: String) = find(MenuItem::class.java,
+      byAttributeAndSwingClass("text", text, JMenuItem::class.java))
+  fun select(text: String) : MenuItem = with(item(text)) { click(); return@select this }
+}
+
+@FixtureName("Dialog")
+class Dialog(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ContainerFixture(remoteRobot, remoteComponent) {
+  fun header() = find(ContainerFixture::class.java, byXpath("//div[@class='DialogHeader']"))
+  fun close() = header().button("Close").click()
+  fun ContainerFixture.sidePanel() = find(ContainerFixture::class.java,
+      byXpath("//div[@class='SidePanel']"))
+}
+
+@FixtureName("Combo Box")
+class ComboBox(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+    : ContainerFixture(remoteRobot, remoteComponent) {
+  fun dropdown() = click()
+}
+
+@FixtureName("Heavy Weight Window")
+@DefaultXpath("HeavyWeightWindow type", "//div[@class='HeavyWeightWindow']")
+class HeavyWeightWindow(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+  : ContainerFixture(remoteRobot, remoteComponent);

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -35,10 +35,8 @@ fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindowFixture::class.jav
 @DefaultXpath(by = "FlatWelcomeFrame type", xpath = "//div[@class='FlatWelcomeFrame']")
 class WelcomeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : CommonContainerFixture(remoteRobot, remoteComponent) {
-  fun newProjectButton() = button(LocatorBuilder()
-          .withAttr("accessiblename", "New Project")
-          .withClass(JButton::class.java)
-          .build())
+  fun newProjectButton() = button(byXpath("//div[(@class='MainButton' and @text='New Project') "
+      + "or (@accessiblename='New Project' and @class='JButton')]"))
 }
 
 @FixtureName("IDE Frame")

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -8,59 +8,74 @@ import com.intellij.remoterobot.fixtures.ContainerFixture
 import com.intellij.remoterobot.fixtures.DefaultXpath
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
+import fi.aalto.cs.apluscourses.e2e.utils.LocatorBuilder
 import java.time.Duration
 import javax.swing.JButton
 import javax.swing.JComboBox
 import javax.swing.JDialog
 import javax.swing.JMenuItem
 
-fun RemoteRobot.welcomeFrame() = find(WelcomeFrame::class.java, Duration.ofSeconds(60))
+fun RemoteRobot.welcomeFrame() = find(WelcomeFrameFixture::class.java, Duration.ofSeconds(60))
 
-fun RemoteRobot.ideFrame() = find(IdeFrame::class.java, Duration.ofSeconds(20))
+fun RemoteRobot.ideFrame() = find(IdeFrameFixture::class.java, Duration.ofSeconds(20))
 
-fun <T> Class<T>.toXPathExp(): String = "@javaclass='$name' or contains(@classhierarchy, '$name')"
+fun SearchContext.button(name: String) = find(ButtonFixture::class.java,
+  LocatorBuilder()
+    .withAttr("accessiblename", name)
+    .withClass(JButton::class.java)
+    .build())
 
-fun <T> byAttributeAndSwingClass(attr : String, value : String, clazz : Class<T>) =
-    byXpath("//div[@$attr='$value' and (${clazz.toXPathExp()})]")
-
-fun SearchContext.button(name: String) = find(Button::class.java,
-    byAttributeAndSwingClass("accessiblename", name, JButton::class.java))
-
-fun SearchContext.comboBox(name: String) = find(ComboBox::class.java,
-    byAttributeAndSwingClass("accessiblename", name, JComboBox::class.java))
+fun SearchContext.comboBox(name: String) = find(ComboBoxFixture::class.java,
+  LocatorBuilder()
+    .withAttr("accessiblename", name)
+    .withClass(JComboBox::class.java)
+    .build())
 
 fun SearchContext.dialog(title: String, timeout : Duration = Duration.ofSeconds(5)) =
-    find(Dialog::class.java, byAttributeAndSwingClass("title", title, JDialog::class.java), timeout)
+    find(DialogFixture::class.java,
+      LocatorBuilder()
+        .withAttr("title", title)
+        .withClass(JDialog::class.java)
+        .build(),
+      timeout)
+
+fun SearchContext.allDialogs() = findAll(DialogFixture::class.java,
+  LocatorBuilder()
+    .withClass(JDialog::class.java)
+    .build())
 
 fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindow::class.java)
 
 @FixtureName("Welcome Frame")
 @DefaultXpath(by = "FlatWelcomeFrame type", xpath = "//div[@class='FlatWelcomeFrame']")
-class WelcomeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class WelcomeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent)
 
 @FixtureName("IDE Frame")
 @DefaultXpath("IdeFrameImpl type", "//div[@class='IdeFrameImpl']")
-class IdeFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class IdeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent) {
-  fun menu() = find(MenuItem::class.java)
+  fun menu() = find(MenuItemFixture::class.java)
 }
 
 @FixtureName("Button")
-class Button(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class ButtonFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ComponentFixture(remoteRobot, remoteComponent)
 
 @FixtureName("Menu Item")
 @DefaultXpath("MenuFrameHeader type", "//div[@class='MenuFrameHeader']")
-class MenuItem(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class MenuItemFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent) {
-  fun item(text: String) = find(MenuItem::class.java,
-      byAttributeAndSwingClass("text", text, JMenuItem::class.java))
-  fun select(text: String) : MenuItem = with(item(text)) { click(); return@select this }
+  fun item(text: String) = find(MenuItemFixture::class.java,
+    LocatorBuilder()
+      .withAttr("text", text)
+      .withClass(JMenuItem::class.java)
+      .build())
+  fun select(text: String) : MenuItemFixture = with(item(text)) { click(); return@select this }
 }
 
 @FixtureName("Dialog")
-class Dialog(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class DialogFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent) {
   fun header() = find(ContainerFixture::class.java, byXpath("//div[@class='DialogHeader']"))
   fun close() = header().button("Close").click()
@@ -69,7 +84,7 @@ class Dialog(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
 }
 
 @FixtureName("Combo Box")
-class ComboBox(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class ComboBoxFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
     : ContainerFixture(remoteRobot, remoteComponent) {
   fun dropdown() = click()
 }

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -44,7 +44,7 @@ fun SearchContext.allDialogs() = findAll(DialogFixture::class.java,
     .withClass(JDialog::class.java)
     .build())
 
-fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindow::class.java)
+fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindowFixture::class.java)
 
 @FixtureName("Welcome Frame")
 @DefaultXpath(by = "FlatWelcomeFrame type", xpath = "//div[@class='FlatWelcomeFrame']")
@@ -91,5 +91,5 @@ class ComboBoxFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent
 
 @FixtureName("Heavy Weight Window")
 @DefaultXpath("HeavyWeightWindow type", "//div[@class='HeavyWeightWindow']")
-class HeavyWeightWindow(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
+class HeavyWeightWindowFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
   : ContainerFixture(remoteRobot, remoteComponent);

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/fixtures/CommonFixtures.kt
@@ -2,30 +2,20 @@ package fi.aalto.cs.apluscourses.e2e.fixtures
 
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.SearchContext
+
 import com.intellij.remoterobot.data.RemoteComponent
-import com.intellij.remoterobot.fixtures.ComponentFixture
-import com.intellij.remoterobot.fixtures.ContainerFixture
-import com.intellij.remoterobot.fixtures.DefaultXpath
-import com.intellij.remoterobot.fixtures.FixtureName
+import com.intellij.remoterobot.fixtures.*
 import com.intellij.remoterobot.search.locators.byXpath
 import fi.aalto.cs.apluscourses.e2e.utils.LocatorBuilder
+import java.awt.Component
 import java.time.Duration
-import javax.swing.JButton
-import javax.swing.JComboBox
-import javax.swing.JDialog
-import javax.swing.JMenuItem
+import javax.swing.*
 
 fun RemoteRobot.welcomeFrame() = find(WelcomeFrameFixture::class.java, Duration.ofSeconds(60))
 
 fun RemoteRobot.ideFrame() = find(IdeFrameFixture::class.java, Duration.ofSeconds(20))
 
-fun SearchContext.button(name: String) = find(ButtonFixture::class.java,
-  LocatorBuilder()
-    .withAttr("accessiblename", name)
-    .withClass(JButton::class.java)
-    .build())
-
-fun SearchContext.comboBox(name: String) = find(ComboBoxFixture::class.java,
+fun SearchContext.customComboBox(name: String) = find(CustomComboBoxFixture::class.java,
   LocatorBuilder()
     .withAttr("accessiblename", name)
     .withClass(JComboBox::class.java)
@@ -39,28 +29,24 @@ fun SearchContext.dialog(title: String, timeout : Duration = Duration.ofSeconds(
         .build(),
       timeout)
 
-fun SearchContext.allDialogs() = findAll(DialogFixture::class.java,
-  LocatorBuilder()
-    .withClass(JDialog::class.java)
-    .build())
-
-fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindowFixture::class.java)
+fun SearchContext.heavyWeightWindow() = find(HeavyWeightWindowFixture::class.java, Duration.ofSeconds(5))
 
 @FixtureName("Welcome Frame")
 @DefaultXpath(by = "FlatWelcomeFrame type", xpath = "//div[@class='FlatWelcomeFrame']")
 class WelcomeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-    : ContainerFixture(remoteRobot, remoteComponent)
+    : CommonContainerFixture(remoteRobot, remoteComponent) {
+  fun newProjectButton() = button(LocatorBuilder()
+          .withAttr("accessiblename", "New Project")
+          .withClass(JButton::class.java)
+          .build())
+}
 
 @FixtureName("IDE Frame")
 @DefaultXpath("IdeFrameImpl type", "//div[@class='IdeFrameImpl']")
 class IdeFrameFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-    : ContainerFixture(remoteRobot, remoteComponent) {
+    : CommonContainerFixture(remoteRobot, remoteComponent) {
   fun menu() = find(MenuItemFixture::class.java)
 }
-
-@FixtureName("Button")
-class ButtonFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-    : ComponentFixture(remoteRobot, remoteComponent)
 
 @FixtureName("Menu Item")
 @DefaultXpath("MenuFrameHeader type", "//div[@class='MenuFrameHeader']")
@@ -76,20 +62,18 @@ class MenuItemFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent
 
 @FixtureName("Dialog")
 class DialogFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-    : ContainerFixture(remoteRobot, remoteComponent) {
-  fun header() = find(ContainerFixture::class.java, byXpath("//div[@class='DialogHeader']"))
-  fun close() = header().button("Close").click()
+    : CommonContainerFixture(remoteRobot, remoteComponent) {
   fun ContainerFixture.sidePanel() = find(ContainerFixture::class.java,
       byXpath("//div[@class='SidePanel']"))
 }
 
-@FixtureName("Combo Box")
-class ComboBoxFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-    : ContainerFixture(remoteRobot, remoteComponent) {
+@FixtureName("Custom Combo Box")
+class CustomComboBoxFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
+  ComponentFixture(remoteRobot, remoteComponent) {
   fun dropdown() = click()
 }
 
 @FixtureName("Heavy Weight Window")
 @DefaultXpath("HeavyWeightWindow type", "//div[@class='HeavyWeightWindow']")
 class HeavyWeightWindowFixture(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent)
-  : ContainerFixture(remoteRobot, remoteComponent);
+  : CommonContainerFixture(remoteRobot, remoteComponent)

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
@@ -3,44 +3,39 @@ package fi.aalto.cs.apluscourses.e2e.steps
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.stepsProcessing.step
 import fi.aalto.cs.apluscourses.e2e.fixtures.*
-import fi.aalto.cs.apluscourses.e2e.utils.wait
 import java.time.Duration
 
 class CommonSteps(val remoteRobot: RemoteRobot) {
 
-  fun createProject() = step("Create New Empty Project") {
-    with(remoteRobot) {
-      with(welcomeFrame()) {
-        button("New Project").click()
-        with(dialog("New Project")) {
-          findText("Empty Project").click()
-          button("Next").click()
-          button("Finish").click()
+  fun createProject() {
+    with (remoteRobot) {
+      step("Create New Empty Project") {
+        with(welcomeFrame()) {
+          newProjectButton().click()
+          with(dialog("New Project")) {
+            findText("Empty Project").click()
+            button("Next").click()
+            button("Finish").click()
+          }
         }
       }
-      wait(Duration.ofSeconds(10))
-      ideFrame().allDialogs().forEach { it.close() }
-    }
-  }
-
-  fun downloadAndSetOpenJdk11() = step("Add OpenJDK 11") {
-    with(remoteRobot.ideFrame()) {
-      menu().select("File").select("Project Structure...")
-      with(dialog("Project Structure")) {
-        sidePanel().findText("Project").click()
-        comboBox("\u001BProject SDK:").dropdown()
-        with(heavyWeightWindow()) {
-          findText("Add SDK").click()
-          heavyWeightWindow().findText("Download JDK...").click()
+      step("Add OpenJDK 11") {
+        with(dialog("Project Structure", Duration.ofSeconds(20))) {
+          sidePanel().findText("Project").click()
+          customComboBox("\u001BProject SDK:").dropdown()
+          with(heavyWeightWindow()) {
+            findText("Add SDK").click()
+            heavyWeightWindow().findText("Download JDK...").click()
+          }
+          with(dialog("Download JDK")) {
+            customComboBox("Version:").click()
+            heavyWeightWindow().findText("11").click()
+            customComboBox("Vendor:").click()
+            heavyWeightWindow().findText("AdoptOpenJDK (HotSpot)").click()
+            button("Download").click()
+          }
+          button("OK").click()
         }
-        with(dialog("Download JDK")) {
-          comboBox("Version:").dropdown()
-          heavyWeightWindow().findText("11").click()
-          comboBox("Vendor:").dropdown()
-          heavyWeightWindow().findText("AdoptOpenJDK (HotSpot)").click()
-          button("Download").click()
-        }
-        button("OK").click()
       }
     }
   }

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
@@ -1,0 +1,56 @@
+package fi.aalto.cs.apluscourses.e2e.steps
+
+import com.intellij.remoterobot.RemoteRobot
+import com.intellij.remoterobot.stepsProcessing.step
+import com.intellij.remoterobot.utils.WaitForConditionTimeoutException
+import fi.aalto.cs.apluscourses.e2e.fixtures.*
+import java.time.Duration
+
+class CommonSteps(val remoteRobot: RemoteRobot) {
+
+  fun createProject() = step("Create New Empty Project") {
+    with(remoteRobot) {
+      with(welcomeFrame()) {
+        button("New Project").click()
+        with(dialog("New Project")) {
+          findText("Empty Project").click()
+          button("Next").click()
+          button("Finish").click()
+        }
+      }
+      ideFrame().dialog("Project Structure", Duration.ofSeconds(20)).close()
+    }
+  }
+
+  fun closeTipOfTheDay() = step("Close Tip of the Day") {
+    with(remoteRobot.ideFrame()) {
+      try {
+        dialog("Tip of the Day").close()
+      } catch (e : WaitForConditionTimeoutException) {
+        print("Tip of the Day not found")
+      }
+    }
+  }
+
+  fun downloadAndSetOpenJdk11() = step("Add OpenJDK 11") {
+    with(remoteRobot.ideFrame()) {
+      menu().select("File").select("Project Structure...")
+      with(dialog("Project Structure")) {
+        sidePanel().findText("Project").click()
+        comboBox("\u001BProject SDK:").dropdown()
+        with(heavyWeightWindow()) {
+          findText("Add SDK").click()
+          heavyWeightWindow().findText("Download JDK...").click()
+        }
+        with(dialog("Download JDK")) {
+          comboBox("Version:").dropdown()
+          heavyWeightWindow().findText("11").click()
+          comboBox("Vendor:").dropdown()
+          heavyWeightWindow().findText("AdoptOpenJDK (HotSpot)").click()
+          button("Download").click()
+        }
+        button("OK").click()
+      }
+    }
+  }
+}

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/steps/CommonSteps.kt
@@ -2,8 +2,8 @@ package fi.aalto.cs.apluscourses.e2e.steps
 
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.stepsProcessing.step
-import com.intellij.remoterobot.utils.WaitForConditionTimeoutException
 import fi.aalto.cs.apluscourses.e2e.fixtures.*
+import fi.aalto.cs.apluscourses.e2e.utils.wait
 import java.time.Duration
 
 class CommonSteps(val remoteRobot: RemoteRobot) {
@@ -18,17 +18,8 @@ class CommonSteps(val remoteRobot: RemoteRobot) {
           button("Finish").click()
         }
       }
-      ideFrame().dialog("Project Structure", Duration.ofSeconds(20)).close()
-    }
-  }
-
-  fun closeTipOfTheDay() = step("Close Tip of the Day") {
-    with(remoteRobot.ideFrame()) {
-      try {
-        dialog("Tip of the Day").close()
-      } catch (e : WaitForConditionTimeoutException) {
-        print("Tip of the Day not found")
-      }
+      wait(Duration.ofSeconds(10))
+      ideFrame().allDialogs().forEach { it.close() }
     }
   }
 

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/LocatorBuilder.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/LocatorBuilder.kt
@@ -17,7 +17,7 @@ class LocatorBuilder {
 
   fun withAttr(attr: String, value: String) = withClause("@$attr='$value'")
 
-  private fun toXpath() = clauses.joinToString(" and ", "//div[", "]");
+  private fun toXpath() = clauses.joinToString(" and ", "//div[", "]")
 
   fun build() = byXpath(toXpath());
 }

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/LocatorBuilder.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/LocatorBuilder.kt
@@ -1,0 +1,23 @@
+package fi.aalto.cs.apluscourses.e2e.utils
+
+import com.intellij.remoterobot.search.locators.byXpath
+
+class LocatorBuilder {
+  private val clauses = mutableListOf<String>()
+
+  fun withClause(clause: String): LocatorBuilder {
+    clauses.add("($clause)")
+    return this
+  }
+
+  fun withClass(className: String) =
+    withClause("@javaclass='$className' or contains(@classhierarchy, '$className')")
+
+  fun <T> withClass(clazz: Class<T>) = withClass(clazz.name)
+
+  fun withAttr(attr: String, value: String) = withClause("@$attr='$value'")
+
+  private fun toXpath() = clauses.joinToString(" and ", "//div[", "]");
+
+  fun build() = byXpath(toXpath());
+}

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
@@ -16,7 +16,7 @@ object StepLoggerInitializer {
 }
 
 fun uiTest(test: RemoteRobot.() -> Unit) {
-  RemoteRobot("http://localhost:8580").test()
+  RemoteRobot("http://localhost:8082").test()
 }
 
 fun wait(duration: Duration) = Thread.sleep(duration.toMillis())

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
@@ -1,0 +1,19 @@
+package fi.aalto.cs.apluscourses.e2e.utils
+
+import com.intellij.remoterobot.RemoteRobot
+import com.intellij.remoterobot.stepsProcessing.StepLogger
+import com.intellij.remoterobot.stepsProcessing.StepWorker
+
+object StepLoggerInitializer {
+  private var initialized = false;
+  fun init() = synchronized(initialized) {
+    if (!initialized) {
+      StepWorker.registerProcessor(StepLogger())
+      initialized = true
+    }
+  }
+}
+
+fun uiTest(test: RemoteRobot.() -> Unit) {
+  RemoteRobot("http://localhost:8580").test()
+}

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.e2e.utils
 import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.stepsProcessing.StepLogger
 import com.intellij.remoterobot.stepsProcessing.StepWorker
+import java.time.Duration
 
 object StepLoggerInitializer {
   private var initialized = false;
@@ -17,3 +18,5 @@ object StepLoggerInitializer {
 fun uiTest(test: RemoteRobot.() -> Unit) {
   RemoteRobot("http://localhost:8580").test()
 }
+
+fun wait(duration: Duration) = Thread.sleep(duration.toMillis())

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
@@ -6,7 +6,7 @@ import com.intellij.remoterobot.stepsProcessing.StepWorker
 import java.time.Duration
 
 object StepLoggerInitializer {
-  private var initialized = false;
+  private var initialized = false
   fun init() = synchronized(initialized) {
     if (!initialized) {
       StepWorker.registerProcessor(StepLogger())

--- a/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
+++ b/src/e2e/kotlin/fi/aalto/cs/apluscourses/e2e/utils/Utils.kt
@@ -4,13 +4,13 @@ import com.intellij.remoterobot.RemoteRobot
 import com.intellij.remoterobot.stepsProcessing.StepLogger
 import com.intellij.remoterobot.stepsProcessing.StepWorker
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
 
 object StepLoggerInitializer {
-  private var initialized = false
-  fun init() = synchronized(initialized) {
-    if (!initialized) {
+  private val initialized = AtomicBoolean(false)
+  fun init() {
+    if (!initialized.getAndSet(true)) {
       StepWorker.registerProcessor(StepLogger())
-      initialized = true
     }
   }
 }


### PR DESCRIPTION
# Description of the PR

Closes #495.

Kotlin is here! This PR contains initial steps for automated end-to-end testing.

That is, creating a new project and setting SDK to OpenJDK 11. Currently, the test only works if
run on clean IDEA.

For UI tests, a new source set "e2e" is introduced. IntelliJ IDEA does not automatically recognize the source set's code as "test" code (green color). For the best development experience, you should change that after updating Gradle (see pic).

![screenshot](https://user-images.githubusercontent.com/6066364/107100341-be89b180-681c-11eb-82e4-1d2a1d9b8371.png)

(Note: building, testing and other important things should work perfectly without any manual configuring. The only things that the fix above concerns are such as when you "Find Usages" in IDEA, whether the code in e2e source set are considered "production" code or "test" code. This is a bug in Gradle's IDEA plug-in that [apparently](https://youtrack.jetbrains.com/issue/IDEA-151925#focus=Comments-27-4614854.0-0) comes and goes, and JetBrains doesn't consider it that important.)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
