### PR TITLE
Add support for potential platform-dependant IDE settings

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporter.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/SettingsImporter.java
@@ -4,6 +4,7 @@ import com.intellij.ide.startup.StartupActionScriptManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.updateSettings.impl.UpdateSettings;
+import com.intellij.openapi.util.SystemInfoRt;
 import com.intellij.openapi.util.io.FileUtilRt;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Course;
@@ -42,9 +43,22 @@ public class SettingsImporter {
    * @throws IOException If an IO error occurs (e.g. network issues).
    */
   public void importIdeSettings(@NotNull Course course) throws IOException {
-    URL ideSettingsUrl = course.getResourceUrls().get("ideSettings");
+    URL ideSettingsUrl = null;
+
+    if (SystemInfoRt.isWindows) {
+      ideSettingsUrl = course.getResourceUrls().get("ideSettingsWindows");
+    } else if (SystemInfoRt.isLinux) {
+      ideSettingsUrl = course.getResourceUrls().get("ideSettingsLinux");
+    } else if (SystemInfoRt.isMac) {
+      ideSettingsUrl = course.getResourceUrls().get("ideSettingsMac");
+    }
+
     if (ideSettingsUrl == null) {
-      return;
+      ideSettingsUrl = course.getResourceUrls().get("ideSettings");
+
+      if (ideSettingsUrl == null) {
+        return;
+      }
     }
 
     File file = FileUtilRt.createTempFile("course-ide-settings", ".zip");


### PR DESCRIPTION
# Description of the PR
Related to issue #468.

This pull request adds the **optional** possibility for course administrators to specify platform-specific IntelliJ IDE settings, separately for Mac, Windows, Linux. When a user turns a project into an A+ project, the plugin will now download and import appropriate settings for the platform the user is currently on. If such platform-specific settings are not found, default will be used.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
