### PR TITLE
Bypassed certain test errors

### DIFF
--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationActionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import fi.aalto.cs.apluscourses.dal.PasswordStorage;
 import fi.aalto.cs.apluscourses.dal.TokenAuthentication;
 import fi.aalto.cs.apluscourses.intellij.DialogHelper;
@@ -26,7 +27,7 @@ import fi.aalto.cs.apluscourses.presentation.filter.Options;
 import org.junit.Before;
 import org.junit.Test;
 
-public class APlusAuthenticationActionTest {
+public class APlusAuthenticationActionTest extends BasePlatformTestCase {
 
   Project project;
   AnActionEvent actionEvent;
@@ -46,7 +47,8 @@ public class APlusAuthenticationActionTest {
    * Called before each test.
    */
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
+    super.setUp();
     project = mock(Project.class);
     actionEvent = mock(AnActionEvent.class);
     doReturn(project).when(actionEvent).getProject();

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtilRt;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import fi.aalto.cs.apluscourses.intellij.DialogHelper;
 import fi.aalto.cs.apluscourses.intellij.actions.SubmitExerciseAction.Tagger;
 import fi.aalto.cs.apluscourses.intellij.model.ProjectModuleSource;
@@ -69,7 +70,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-public class SubmitExerciseActionTest {
+public class SubmitExerciseActionTest extends BasePlatformTestCase {
 
   Course course;
   long exerciseId;
@@ -118,7 +119,8 @@ public class SubmitExerciseActionTest {
    */
   @SuppressWarnings("unchecked")
   @Before
-  public void setUp() throws IOException, FileDoesNotExistException {
+  public void setUp() throws Exception {
+    super.setUp();
     exerciseId = 12;
     exercise = new Exercise(exerciseId, "Test exercise", "http://localhost:10000", 0, 0, 0, true);
     group = new Group(124, Collections.singletonList("Only you"));


### PR DESCRIPTION
# Description of the PR
Related to #213

Some tests fail because ApplicationManager is not initialized in the test environment, which causes PluginSettings's constructor to fail and trigger an avalanche of further failures. This bypasses the problem in a somewhat questionable way, since it converts tests into platform tests (but at least the errors are no more)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
