### PR TITLE
Fixes IllegalStateException related to exercises tree

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
@@ -12,6 +12,7 @@ import fi.aalto.cs.apluscourses.ui.base.TreeView;
 import icons.PluginIcons;
 import javax.swing.Icon;
 import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
 import org.jetbrains.annotations.NotNull;
 
 public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
@@ -45,6 +46,9 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
                                     boolean isLeaf,
                                     int row,
                                     boolean hasFocus) {
+    if (isIrrelevantNode(value)) {
+      return;
+    }
     SelectableNodeViewModel<?> viewModel = TreeView.getViewModel(value);
     if (viewModel instanceof ExerciseViewModel) {
       ExerciseViewModel exerciseViewModel = (ExerciseViewModel) viewModel;
@@ -76,5 +80,22 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
       append(" [" + resultViewModel.getStatusText() + "]", STATUS_TEXT_STYLE, false);
       setToolTipText(getText("ui.exercise.ExercisesTreeRenderer.doubleClickToOpenBrowser"));
     }
+  }
+
+  /**
+   * Sometimes {@code customizeCellRenderer} is called with a value
+   * that is just some placeholder object for tree root.
+   *
+   * This method recognizes such cases.
+   *
+   * @param value A parameter passed to {@code customizeCellRenderer}
+   * @return True, if node is irrelevant and should be ignored, otherwise false.
+   */
+  private boolean isIrrelevantNode(Object value) {
+    // That irrelevant root has no user object
+    // We assume that all relevant nodes that implement DefaultMutableTreeNode
+    // do have user objects.
+    return value instanceof DefaultMutableTreeNode
+        && ((DefaultMutableTreeNode) value).getUserObject() == null;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
@@ -85,7 +85,6 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
   /**
    * Sometimes {@code customizeCellRenderer} is called with a value
    * that is just some placeholder object for tree root.
-   *
    * This method recognizes such cases.
    *
    * @param value A parameter passed to {@code customizeCellRenderer}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.java
@@ -91,10 +91,8 @@ public class ExercisesTreeRenderer extends ColoredTreeCellRenderer {
    * @return True, if node is irrelevant and should be ignored, otherwise false.
    */
   private boolean isIrrelevantNode(Object value) {
-    // That irrelevant root has no user object
-    // We assume that all relevant nodes that implement DefaultMutableTreeNode
-    // do have user objects.
+    // That irrelevant root has no parent
     return value instanceof DefaultMutableTreeNode
-        && ((DefaultMutableTreeNode) value).getUserObject() == null;
+        && ((DefaultMutableTreeNode) value).getParent() == null;
   }
 }


### PR DESCRIPTION
# Description of the PR

+ A quick fix to eliminate `java.lang.IllegalStateException: @NotNull method fi/aalto/cs/apluscourses/ui/utils/TreeModelBuilder.getUserObject must not return null`

+ Now, before `ExercisesTreeRenderer::customizeCellRenderer` handles a node, it checks if it happens to be an "irrelevant" placeholder node which should just be ignored.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
