### PR TITLE
Explicitly specified separator sizes for table labels

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.form
@@ -19,7 +19,9 @@
         <children>
           <component id="8a531" class="javax.swing.JToolBar$Separator">
             <constraints/>
-            <properties/>
+            <properties>
+              <separatorSize width="10" height="0"/>
+            </properties>
           </component>
           <component id="de40" class="javax.swing.JLabel">
             <constraints/>
@@ -29,7 +31,9 @@
           </component>
           <component id="5c667" class="javax.swing.JToolBar$Separator">
             <constraints/>
-            <properties/>
+            <properties>
+              <separatorSize width="10" height="0"/>
+            </properties>
           </component>
         </children>
       </grid>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.form
@@ -21,7 +21,9 @@
         <children>
           <component id="ce006" class="javax.swing.JToolBar$Separator">
             <constraints/>
-            <properties/>
+            <properties>
+              <separatorSize width="10" height="0"/>
+            </properties>
           </component>
           <component id="a54c3" class="javax.swing.JLabel">
             <constraints/>
@@ -31,7 +33,9 @@
           </component>
           <component id="2132d" class="javax.swing.JToolBar$Separator">
             <constraints/>
-            <properties/>
+            <properties>
+              <separatorSize width="10" height="0"/>
+            </properties>
           </component>
         </children>
       </grid>


### PR DESCRIPTION
# Description of the PR
Related to #294.

This pull request sets the label separator sizes explicitly for modules and assignments lists. This should have no effect on Windows and Linux users but should fix a Mac issue where the separator size is by default 0 (which is by design for some reason).

Before:
![Screenshot 2021-02-15 at 17 22 29](https://user-images.githubusercontent.com/73069541/107972133-0f876b80-6fbc-11eb-8d63-6808e0a8d894.png)

After:
![Screenshot 2021-02-15 at 17 23 06](https://user-images.githubusercontent.com/73069541/107972142-131af280-6fbc-11eb-9a78-85085d6c919b.png)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
