### PR TITLE
Update zip4j to v2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
-    compile group: 'net.lingala.zip4j', name: 'zip4j', version: '2.6.3'
+    compile group: 'net.lingala.zip4j', name: 'zip4j', version: '2.7.0'
     compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.13.4'
     implementation group: 'org.json', name: 'json', version: '20190722'
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
# Description of the PR

The currently used version 2.6.3 of zip4j has a vulnerability:
https://snyk.io/test/github/Aalto-LeTech/intellij-plugin?targetFile=build.gradle

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
