### PR TITLE
Remove Scala compilation warnings

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -23,7 +23,7 @@ import org.jetbrains.plugins.scala.console.actions.RunConsoleAction
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfiguration
 import org.jetbrains.plugins.scala.project.ProjectExt
 
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
  * Custom class that adjusts Scala Plugin's own RunConsoleAction with A+ requirements.
@@ -116,13 +116,16 @@ class ReplAction extends RunConsoleAction {
 
   def getDefaultModule(@NotNull project: Project): Option[Module] = {
     Option(PluginSettings.getInstance().getMainViewModel(project).courseViewModel.get) match {
-      case Some(courseViewModel) =>
-        Option(ModuleManager.getInstance(project).findModuleByName(courseViewModel
-          .getModel
-          .getAutoInstallComponentNames
-          //  we, hereby, commonly agree, that the first in the list auto install component (module)
-          //  is ultimately REPL's default module (as it's most likely to exist). sorry :pensive:
-          .head))
+      case Some(courseViewModel) => {
+        Option(ModuleManager.getInstance(project).findModuleByName(
+          courseViewModel
+            .getModel
+            .getAutoInstallComponentNames
+            .asScala
+            //  we, hereby, commonly agree, that the first in the list auto install component (module)
+            //  is ultimately REPL's default module (as it's most likely to exist). sorry :pensive:
+            .head))
+      }
       case None => None
     }
   }

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -116,7 +116,7 @@ class ReplAction extends RunConsoleAction {
 
   def getDefaultModule(@NotNull project: Project): Option[Module] = {
     Option(PluginSettings.getInstance().getMainViewModel(project).courseViewModel.get) match {
-      case Some(courseViewModel) => {
+      case Some(courseViewModel) =>
         Option(ModuleManager.getInstance(project).findModuleByName(
           courseViewModel
             .getModel
@@ -125,7 +125,6 @@ class ReplAction extends RunConsoleAction {
             //  we, hereby, commonly agree, that the first in the list auto install component (module)
             //  is ultimately REPL's default module (as it's most likely to exist). sorry :pensive:
             .head))
-      }
       case None => None
     }
   }

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
@@ -1,9 +1,5 @@
 package fi.aalto.cs.apluscourses.intellij.utils
 
-import java.io.IOException
-import java.nio.charset.StandardCharsets
-import java.nio.file.Paths
-
 import com.intellij.openapi.actionSystem.{CommonDataKeys, DataContext}
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.keymap.KeymapManager
@@ -17,7 +13,10 @@ import org.apache.commons.io.FileUtils
 import org.jetbrains.annotations.NotNull
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters.asJavaCollection
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+import scala.jdk.javaapi.CollectionConverters.asJava
 
 object ModuleUtils {
 
@@ -125,7 +124,7 @@ object ModuleUtils {
       .get(getModuleDirectory(module), PluginSettings.MODULE_REPL_INITIAL_COMMANDS_FILE_NAME)
       .toFile
     if (commands.nonEmpty && !file.exists) {
-      try FileUtils.writeLines(file, StandardCharsets.UTF_8.name, asJavaCollection(commands))
+      try FileUtils.writeLines(file, StandardCharsets.UTF_8.name, asJava(commands))
       catch {
         case ex: IOException => Logger.error("Could not write REPL initial commands file", ex)
       }


### PR DESCRIPTION
Get rid of Scala compiler warnings #504

# Description of the PR

+ removes the warnings

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [x] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
