### PR TITLE
Make exercise "in grading" status change thread safe

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -111,11 +111,10 @@ public class SubmissionStatusUpdater {
               dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
           if (SubmissionResult.Status.WAITING.equals(submissionResult.getStatus())) {
             PluginSettings.getInstance().getMainViewModel(project).setSubmittedForGrading(exercise);
-            PluginSettings.getInstance().updateMainViewModel(project);
           } else if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
             notifier.notifyAndHide(
                 new FeedbackAvailableNotification(submissionResult, exercise), project);
-            PluginSettings.getInstance().getMainViewModel(project).setSubmittedForGrading(null);
+            PluginSettings.getInstance().getMainViewModel(project).setGradingDone(exercise);
             PluginSettings.getInstance().updateMainViewModel(project);
             return;
           }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/observable/ObservableProperty.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/observable/ObservableProperty.java
@@ -80,6 +80,14 @@ public abstract class ObservableProperty<T> {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Notifies all observers with the current value. Works similarly to {@link
+   * ObservableProperty#set}, but the actual value isn't changed.
+   */
+  public void valueChanged() {
+    onValueChanged(get(), null);
+  }
+
   protected synchronized void onValueChanged(@Nullable T value, @Nullable Object source) {
     for (Map.Entry<Object, Callback<?, T>> entry : observers.entrySet()) {
       Object observer = entry.getKey();


### PR DESCRIPTION
This is a minor change to Stella's PR, which includes thread safety, avoiding repeated API requests, and supporting multiple exercises in grading.