### PR TITLE
Add "loading" to modules view

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/toolwindows/APlusToolWindowFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/toolwindows/APlusToolWindowFactory.java
@@ -42,6 +42,10 @@ public class APlusToolWindowFactory extends BaseToolWindowFactory implements Dum
     PluginSettings.getInstance().getMainViewModel(project).courseViewModel
         .addValueObserver(modulesView, ModulesView::viewModelChanged);
 
+    InitializationActivity
+        .isInitialized(project)
+        .addValueObserver(modulesView, ModulesView::setProjectReady);
+
     ActionManager actionManager = ActionManager.getInstance();
     ActionGroup group = (ActionGroup) actionManager.getAction(ActionGroups.MODULE_ACTIONS);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.java
@@ -68,14 +68,21 @@ public class ModulesView {
     ApplicationManager.getApplication().invokeLater(() -> {
       moduleListView.setModel(course == null ? null : course.getModules());
       cl.show(cardPanel, (course != null) ? "TreeCard" : "LabelCard");
-      if (course == null) { //and is ready, but cannot know that with a null model!
-        emptyText.setText(getText("ui.module.ModuleListView.turnIntoAPlusProject"));
-      }
     }, ModalityState.any()
     );
   }
 
   public JLabel getEmptyText() {
     return emptyText;
+  }
+
+  /**
+   * Determines whether the empty text shows that the project is loading or that the user should
+   * turn the project into a course project.
+   */
+  public void setProjectReady(boolean isReady) {
+    ApplicationManager.getApplication().invokeLater(() -> emptyText.setText(isReady
+        ? getText("ui.module.ModuleListView.turnIntoAPlusProject")
+        : getText("ui.exercise.ExercisesView.loading")), ModalityState.any());
   }
 }


### PR DESCRIPTION
# Description of the PR

Adds a "loading" text to the modules view during project initialization. As Stella found out, the course view model is null when the project isn't a course project, so it can't be used to determine whether the project isn't a course project or whether it simply isn't initialized. For simplicity I just added a method to the view.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
