### PR TITLE
Fix scrolling speed in exercises tree

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.java
@@ -41,7 +41,9 @@ public class ExercisesView {
     emptyText.setText(getText("ui.exercise.ExercisesView.loading"));
     emptyText.setHorizontalAlignment(SwingConstants.CENTER);
     emptyText.setVerticalAlignment(SwingConstants.CENTER);
-    pane.getVerticalScrollBar().setUnitIncrement(exerciseGroupsTree.getRowHeight());
+    var rowHeight = exerciseGroupsTree.getRowHeight();
+    // Row height returns <= 0 on some platforms, so a default alternative is needed
+    pane.getVerticalScrollBar().setUnitIncrement(rowHeight <= 0 ? 20 : rowHeight);
   }
 
   @NotNull


### PR DESCRIPTION
# Description of the PR

On some platforms `getRowHeight` returns 0, which basically disables scrolling with the scroll-wheel in the exercises tree.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
