### PR TITLE
Cache responses from the A+ API

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -1,12 +1,14 @@
 package fi.aalto.cs.apluscourses.dal;
 
 import fi.aalto.cs.apluscourses.model.Authentication;
+import fi.aalto.cs.apluscourses.model.Cache;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.ExerciseDataSource;
 import fi.aalto.cs.apluscourses.model.ExerciseGroup;
 import fi.aalto.cs.apluscourses.model.Group;
 import fi.aalto.cs.apluscourses.model.InvalidAuthenticationException;
+import fi.aalto.cs.apluscourses.model.JsonCache;
 import fi.aalto.cs.apluscourses.model.Points;
 import fi.aalto.cs.apluscourses.model.Submission;
 import fi.aalto.cs.apluscourses.model.SubmissionHistory;
@@ -17,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,13 +47,15 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   @NotNull
   private final Parser parser;
 
+
   /**
    * Default constructor.
    */
-  public APlusExerciseDataSource(@NotNull String apiUrl) {
-    this(apiUrl,
-        DefaultDataAccess.INSTANCE,
-        DefaultDataAccess.INSTANCE);
+  public APlusExerciseDataSource(@NotNull String apiUrl, @NotNull Path cacheFile) {
+    var dataAccess = new DefaultDataAccess(new JsonCache(cacheFile));
+    this.client = dataAccess;
+    this.parser = dataAccess;
+    this.apiUrl = apiUrl;
   }
 
   /**
@@ -192,17 +197,25 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
 
   public static class DefaultDataAccess implements Client, Parser {
 
-    public static final DefaultDataAccess INSTANCE = new DefaultDataAccess();
+    @NotNull
+    private final Cache<String, JSONObject> cache;
 
-    private DefaultDataAccess() {
-
+    public DefaultDataAccess(@NotNull Cache<String, JSONObject> cache) {
+      this.cache = cache;
     }
 
     @Override
-    public JSONObject fetch(@NotNull String url, @Nullable Authentication authentication)
-        throws IOException {
+    public JSONObject fetch(@NotNull String url,
+                            @Nullable Authentication authentication,
+                            @NotNull ZonedDateTime minCacheEntryTime) throws IOException {
+      var cacheEntry = cache.getEntry(url);
+      if (cacheEntry != null && cacheEntry.getCreationTime().compareTo(minCacheEntryTime) >= 0) {
+        return cacheEntry.getValue();
+      }
       try (InputStream inputStream = CoursesClient.fetch(new URL(url), authentication)) {
-        return new JSONObject(new JSONTokener(inputStream));
+        var response = new JSONObject(new JSONTokener(inputStream));
+        cache.putValue(url, response);
+        return response;
       }
     }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -154,10 +154,11 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   @NotNull
   public SubmissionResult getSubmissionResult(@NotNull String submissionUrl,
                                               @NotNull Exercise exercise,
-                                              @NotNull Authentication authentication)
+                                              @NotNull Authentication authentication,
+                                              @NotNull ZonedDateTime minCacheEntryTime)
       throws IOException {
-    JSONObject response = client.fetch(submissionUrl, authentication);
-    return parser.parseSubmissionResult(response, exercise);
+    JSONObject response = client.fetch(submissionUrl, authentication, minCacheEntryTime);
+    return SubmissionResult.fromJsonObject(response, exercise);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -158,7 +158,7 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
                                               @NotNull ZonedDateTime minCacheEntryTime)
       throws IOException {
     JSONObject response = client.fetch(submissionUrl, authentication, minCacheEntryTime);
-    return SubmissionResult.fromJsonObject(response, exercise);
+    return parser.parseSubmissionResult(response, exercise);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/Client.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/Client.java
@@ -2,12 +2,22 @@ package fi.aalto.cs.apluscourses.dal;
 
 import fi.aalto.cs.apluscourses.model.Authentication;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 
 public interface Client {
-  JSONObject fetch(@NotNull String url, @NotNull Authentication authentication) throws IOException;
+  JSONObject fetch(@NotNull String url,
+                   @NotNull Authentication authentication,
+                   @NotNull ZonedDateTime minCacheEntryTime) throws IOException;
+
+  default JSONObject fetch(@NotNull String url,
+                           @NotNull Authentication authentication) throws IOException {
+    // Ignore all cache entries by default
+    return fetch(url, authentication, OffsetDateTime.MAX.toZonedDateTime());
+  }
 
   String post(@NotNull String url,
               @NotNull Authentication authentication,

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseProject.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseProject.java
@@ -25,7 +25,6 @@ public class CourseProject {
   @NotNull
   private final Course course;
 
-  @NotNull
   private volatile List<ExerciseGroup> exerciseGroups;
 
   private final AtomicBoolean hasTriedToReadAuthenticationFromStorage = new AtomicBoolean(false);
@@ -98,7 +97,7 @@ public class CourseProject {
     return course;
   }
 
-  @NotNull
+  @Nullable
   public List<ExerciseGroup> getExerciseGroups() {
     return exerciseGroups;
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
@@ -7,7 +7,6 @@ import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Exercise;
-import fi.aalto.cs.apluscourses.model.ExerciseDataSource;
 import fi.aalto.cs.apluscourses.model.Points;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.utils.Event;
@@ -63,6 +62,10 @@ public class ExercisesUpdater extends RepeatedTask {
       }
       points.setSubmittableExercises(course.getExerciseModules().keySet()); // TODO: remove
       var exerciseGroups = dataSource.getExerciseGroups(course, points, authentication);
+      if (courseProject.getExerciseGroups() == null) {
+        courseProject.setExerciseGroups(exerciseGroups);
+        eventToTrigger.trigger();
+      }
       for (var exerciseGroup : exerciseGroups) {
         for (var exercise : exerciseGroup.getExercises().values()) {
           if (Thread.interrupted()) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
@@ -4,9 +4,20 @@ import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
 import fi.aalto.cs.apluscourses.intellij.notifications.NetworkErrorNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
+import fi.aalto.cs.apluscourses.model.Authentication;
+import fi.aalto.cs.apluscourses.model.Course;
+import fi.aalto.cs.apluscourses.model.Exercise;
+import fi.aalto.cs.apluscourses.model.ExerciseDataSource;
+import fi.aalto.cs.apluscourses.model.Points;
+import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.utils.Event;
 import fi.aalto.cs.apluscourses.utils.async.RepeatedTask;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.jetbrains.annotations.NotNull;
 
 public class ExercisesUpdater extends RepeatedTask {
@@ -16,6 +27,8 @@ public class ExercisesUpdater extends RepeatedTask {
   private final Event eventToTrigger;
 
   private final Notifier notifier;
+
+  private final Set<Long> submissionsInGrading = ConcurrentHashMap.newKeySet();
 
   /**
    * Construct an updater with the given parameters.
@@ -50,6 +63,14 @@ public class ExercisesUpdater extends RepeatedTask {
       }
       points.setSubmittableExercises(course.getExerciseModules().keySet()); // TODO: remove
       var exerciseGroups = dataSource.getExerciseGroups(course, points, authentication);
+      for (var exerciseGroup : exerciseGroups) {
+        for (var exercise : exerciseGroup.getExercises().values()) {
+          if (Thread.interrupted()) {
+            return;
+          }
+          addSubmissionResults(course, exercise, points, authentication);
+        }
+      }
       if (Thread.interrupted()) {
         return;
       }
@@ -66,6 +87,31 @@ public class ExercisesUpdater extends RepeatedTask {
         observable.valueChanged();
       }
       notifier.notify(new NetworkErrorNotification(e), courseProject.getProject());
+    }
+  }
+
+  private void addSubmissionResults(@NotNull Course course,
+                                    @NotNull Exercise exercise,
+                                    @NotNull Points points,
+                                    @NotNull Authentication authentication)
+      throws IOException {
+    var dataSource = course.getExerciseDataSource();
+    var baseUrl = course.getApiUrl() + "submissions/";
+    var submissionIds = points.getSubmissions().get(exercise.getId());
+    for (var id : submissionIds) {
+      // Ignore cache for submissions that had the status WAITING
+      var cacheTime = submissionsInGrading.remove(id)
+          ? OffsetDateTime.MAX.toZonedDateTime()
+          : ZonedDateTime.now().minusDays(7);
+      var submission = dataSource.getSubmissionResult(
+          baseUrl + id + "/", exercise, authentication, cacheTime);
+      if (submission.getStatus() == SubmissionResult.Status.WAITING) {
+        submissionsInGrading.add(id);
+      }
+      exercise.addSubmissionResult(submission);
+      if (Thread.interrupted()) {
+        return;
+      }
     }
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -74,7 +74,8 @@ class IntelliJCourse extends Course {
     this.project = project;
     this.commonLibraryProvider = commonLibraryProvider;
     this.platformListener = new PlatformListener();
-    this.exerciseDataSource = new APlusExerciseDataSource(getApiUrl());
+    this.exerciseDataSource = new APlusExerciseDataSource(getApiUrl(), project.getBasePath()
+        .resolve(Paths.get(Project.DIRECTORY_STORE_FOLDER, "a-plus-cache.json")));
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
@@ -69,7 +69,7 @@ public abstract class Cache<KeyT, ValueT> {
    */
   public Cache(@NotNull Path filePath) {
     this.file = filePath.toFile();
-    new Thread(this::initialFileRead).start();
+    new Thread(this::doInitialFileRead).start();
   }
 
   /**
@@ -98,7 +98,7 @@ public abstract class Cache<KeyT, ValueT> {
   protected abstract void toFile(@NotNull File file,
                                  @NotNull Map<KeyT, Entry> entries) throws IOException;
 
-  private void initialFileRead() {
+  private void doInitialFileRead() {
     try {
       entries = fromFile(file);
     } catch (IOException e) {
@@ -141,8 +141,6 @@ public abstract class Cache<KeyT, ValueT> {
    */
   private void queueFileWrite() {
     if (writePending.compareAndSet(false, true)) {
-      // The write delay ensures that multiple writes within a 10 second window (caused by frequent
-      // insertions) get coalesced into a single write.
       writeExecutor.schedule(this::writeFile, 10, TimeUnit.SECONDS);
     }
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A cache is essentially a map backed by a file. For each value, the time of creation is also
  * stored so that clients can determine the age of the cache entry. A subclass needs to implement
- * {@link Cache#toFile} and {@link Cache#fromFile}, which read and write the entries to a file. The
+ * {@link Cache#fromFile} and {@link Cache#toFile}, which read and write the entries to a file. The
  * file format is completely up to the client. The file is read once when the cache is instantiated.
  * Writes occur after each insertion, but bursts of insertions only cause one write. Reading and
  * writing is done in a background thread, so a read or write may take a long time without blocking

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
@@ -24,26 +24,26 @@ import org.jetbrains.annotations.Nullable;
  * other code. Note, that the cache makes no guarantee that every entry inserted is also written to
  * the file.
  */
-public abstract class Cache<KeyT, ValueT> {
+public abstract class Cache<K, V> {
 
   public class Entry {
     @NotNull
-    private final ValueT value;
+    private final V value;
 
     @NotNull
     private final ZonedDateTime createdAt;
 
-    public Entry(@NotNull ValueT value, @NotNull ZonedDateTime createdAt) {
+    public Entry(@NotNull V value, @NotNull ZonedDateTime createdAt) {
       this.value = value;
       this.createdAt = createdAt;
     }
 
-    public Entry(@NotNull ValueT value) {
+    public Entry(@NotNull V value) {
       this(value, ZonedDateTime.now());
     }
 
     @NotNull
-    public ValueT getValue() {
+    public V getValue() {
       return value;
     }
 
@@ -55,7 +55,7 @@ public abstract class Cache<KeyT, ValueT> {
 
   private final File file;
 
-  private Map<KeyT, Entry> entries;
+  private volatile Map<K, Entry> entries;
 
   private final CountDownLatch fileRead = new CountDownLatch(1);
 
@@ -67,7 +67,7 @@ public abstract class Cache<KeyT, ValueT> {
   /**
    * Construct an instance with the given underlying file.
    */
-  public Cache(@NotNull Path filePath) {
+  protected Cache(@NotNull Path filePath) {
     this.file = filePath.toFile();
     new Thread(this::doInitialFileRead).start();
   }
@@ -76,7 +76,7 @@ public abstract class Cache<KeyT, ValueT> {
    * Returns the entry corresponding to the given key, or null if no such entry exists.
    */
   @Nullable
-  public synchronized Entry getEntry(@NotNull KeyT key) {
+  public synchronized Entry getEntry(@NotNull K key) {
     ensureFileIsRead();
     return entries.get(key);
   }
@@ -85,18 +85,18 @@ public abstract class Cache<KeyT, ValueT> {
    * Adds the given key and value to the cache. The creation time is determined by
    * {@link ZonedDateTime#now}. If an entry exists with the given key, it is replaced.
    */
-  public synchronized void putValue(@NotNull KeyT key, @NotNull ValueT value) {
+  public synchronized void putValue(@NotNull K key, @NotNull V value) {
     ensureFileIsRead();
     entries.put(key, new Entry(value));
     queueFileWrite();
   }
 
   @NotNull
-  protected abstract Map<KeyT, Entry> fromFile(@NotNull File file) throws IOException;
+  protected abstract Map<K, Entry> fromFile(@NotNull File file) throws IOException;
 
   @NotNull
   protected abstract void toFile(@NotNull File file,
-                                 @NotNull Map<KeyT, Entry> entries) throws IOException;
+                                 @NotNull Map<K, Entry> entries) throws IOException;
 
   private void doInitialFileRead() {
     try {
@@ -109,7 +109,7 @@ public abstract class Cache<KeyT, ValueT> {
   }
 
   private void writeFile() {
-    Map<KeyT, Entry> copy;
+    Map<K, Entry> copy;
     synchronized (this) {
       copy = new HashMap<>(entries);
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
@@ -101,7 +101,6 @@ public abstract class Cache<KeyT, ValueT> {
   private void initialFileRead() {
     try {
       entries = fromFile(file);
-      System.out.println("File successfully read");
     } catch (IOException e) {
       entries = new HashMap<>();
     } finally {
@@ -115,9 +114,7 @@ public abstract class Cache<KeyT, ValueT> {
       copy = new HashMap<>(entries);
     }
     try {
-      System.out.println("Beginning file write");
       toFile(file, copy);
-      System.out.println("File write complete");
     } catch (IOException e) {
       // Ignore
     } finally {
@@ -144,12 +141,9 @@ public abstract class Cache<KeyT, ValueT> {
    */
   private void queueFileWrite() {
     if (writePending.compareAndSet(false, true)) {
-      System.out.println("Write queued");
       // The write delay ensures that multiple writes within a 10 second window (caused by frequent
       // insertions) get coalesced into a single write.
       writeExecutor.schedule(this::writeFile, 10, TimeUnit.SECONDS);
-    } else {
-      System.out.println("Write already queued");
     }
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Cache.java
@@ -1,0 +1,156 @@
+package fi.aalto.cs.apluscourses.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A cache is essentially a map backed by a file. For each value, the time of creation is also
+ * stored so that clients can determine the age of the cache entry. A subclass needs to implement
+ * {@link Cache#toFile} and {@link Cache#fromFile}, which read and write the entries to a file. The
+ * file format is completely up to the client. The file is read once when the cache is instantiated.
+ * Writes occur after each insertion, but bursts of insertions only cause one write. Reading and
+ * writing is done in a background thread, so a read or write may take a long time without blocking
+ * other code. Note, that the cache makes no guarantee that every entry inserted is also written to
+ * the file.
+ */
+public abstract class Cache<KeyT, ValueT> {
+
+  public class Entry {
+    @NotNull
+    private final ValueT value;
+
+    @NotNull
+    private final ZonedDateTime createdAt;
+
+    public Entry(@NotNull ValueT value, @NotNull ZonedDateTime createdAt) {
+      this.value = value;
+      this.createdAt = createdAt;
+    }
+
+    public Entry(@NotNull ValueT value) {
+      this(value, ZonedDateTime.now());
+    }
+
+    @NotNull
+    public ValueT getValue() {
+      return value;
+    }
+
+    @NotNull
+    public ZonedDateTime getCreationTime() {
+      return createdAt;
+    }
+  }
+
+  private final File file;
+
+  private Map<KeyT, Entry> entries;
+
+  private final CountDownLatch fileRead = new CountDownLatch(1);
+
+  private final AtomicBoolean writePending = new AtomicBoolean(false);
+
+  private final ScheduledExecutorService writeExecutor
+      = Executors.newSingleThreadScheduledExecutor();
+
+  /**
+   * Construct an instance with the given underlying file.
+   */
+  public Cache(@NotNull Path filePath) {
+    this.file = filePath.toFile();
+    new Thread(this::initialFileRead).start();
+  }
+
+  /**
+   * Returns the entry corresponding to the given key, or null if no such entry exists.
+   */
+  @Nullable
+  public synchronized Entry getEntry(@NotNull KeyT key) {
+    ensureFileIsRead();
+    return entries.get(key);
+  }
+
+  /**
+   * Adds the given key and value to the cache. The creation time is determined by
+   * {@link ZonedDateTime#now}. If an entry exists with the given key, it is replaced.
+   */
+  public synchronized void putValue(@NotNull KeyT key, @NotNull ValueT value) {
+    ensureFileIsRead();
+    entries.put(key, new Entry(value));
+    queueFileWrite();
+  }
+
+  @NotNull
+  protected abstract Map<KeyT, Entry> fromFile(@NotNull File file) throws IOException;
+
+  @NotNull
+  protected abstract void toFile(@NotNull File file,
+                                 @NotNull Map<KeyT, Entry> entries) throws IOException;
+
+  private void initialFileRead() {
+    try {
+      entries = fromFile(file);
+      System.out.println("File successfully read");
+    } catch (IOException e) {
+      entries = new HashMap<>();
+    } finally {
+      fileRead.countDown();
+    }
+  }
+
+  private void writeFile() {
+    Map<KeyT, Entry> copy;
+    synchronized (this) {
+      copy = new HashMap<>(entries);
+    }
+    try {
+      System.out.println("Beginning file write");
+      toFile(file, copy);
+      System.out.println("File write complete");
+    } catch (IOException e) {
+      // Ignore
+    } finally {
+      writePending.set(false);
+    }
+  }
+
+  /*
+   * Blocks until the file associated with this cache has been parsed. If the file has already been
+   * read, then this method returns immediately.
+   */
+  private void ensureFileIsRead() {
+    try {
+      fileRead.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /*
+   * If a write is already pending, does nothing. Otherwise creates a pending write, which runs in
+   * the background after 10 seconds. This method can be called after each insertion into the cache;
+   * the delay ensures that a burst of entries get coalesced into a single file write.
+   */
+  private void queueFileWrite() {
+    if (writePending.compareAndSet(false, true)) {
+      System.out.println("Write queued");
+      // The write delay ensures that multiple writes within a 10 second window (caused by frequent
+      // insertions) get coalesced into a single write.
+      writeExecutor.schedule(this::writeFile, 10, TimeUnit.SECONDS);
+    } else {
+      System.out.println("Write already queued");
+    }
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
@@ -1,6 +1,7 @@
 package fi.aalto.cs.apluscourses.model;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +32,8 @@ public interface ExerciseDataSource {
   @NotNull
   SubmissionResult getSubmissionResult(@NotNull String submissionUrl,
                                        @NotNull Exercise exercise,
-                                       @NotNull Authentication authentication) throws IOException;
+                                       @NotNull Authentication authentication,
+                                       @NotNull ZonedDateTime minCacheEntryTime) throws IOException;
 
   @Nullable
   String submit(@NotNull Submission submission, @NotNull Authentication authentication)

--- a/src/main/java/fi/aalto/cs/apluscourses/model/JsonCache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/JsonCache.java
@@ -1,0 +1,47 @@
+package fi.aalto.cs.apluscourses.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+
+public class JsonCache extends Cache<String, JSONObject> {
+  
+  public JsonCache(@NotNull Path filePath) {
+    super(filePath);
+  }
+
+  @Override
+  protected @NotNull Map<String, Entry> fromFile(@NotNull File file) throws IOException {
+    Map<String, Entry> entries = new HashMap<>();
+    var json = new JSONObject(FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    Iterable<String> keys = json::keys;
+    for (String url : keys) {
+      var entryJson = json.getJSONObject(url);
+      var createdAt = ZonedDateTime.parse(entryJson.getString("createdAt"));
+      var value = entryJson.getJSONObject("value");
+      entries.put(url, new Entry(value, createdAt));
+    }
+    return entries;
+  }
+
+  @Override
+  protected void toFile(@NotNull File file,
+                        @NotNull Map<String, Entry> entries) throws IOException {
+    var json = new JSONObject();
+    entries.forEach((url, entry) -> {
+      var entryJson = new JSONObject();
+      entryJson.put("createdAt", entry.getCreationTime().toString());
+      entryJson.put("value", entry.getValue());
+      json.put(url, entryJson);
+    });
+    FileUtils.writeStringToFile(file, json.toString(), StandardCharsets.UTF_8);
+  }
+
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -6,6 +6,8 @@ import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotifica
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,6 +102,10 @@ public class SubmissionStatusUpdater {
 
   private void run() {
     try {
+      var courseProject = PluginSettings.getInstance().getCourseProject(project);
+      if (courseProject != null) {
+        courseProject.getExercisesUpdater().restart();
+      }
       while (true) { //  NOSONAR
         if (totalTime >= timeLimit) {
           return;
@@ -121,14 +127,12 @@ public class SubmissionStatusUpdater {
   private boolean fetchResultsAndNotify() {
     SubmissionResult submissionResult;
     try {
-      submissionResult =
-          dataSource.getSubmissionResult(submissionUrl, exercise, authentication);
-      if (SubmissionResult.Status.WAITING.equals(submissionResult.getStatus())) {
-        PluginSettings.getInstance().getMainViewModel(project).setSubmittedForGrading(exercise);
-      } else if (submissionResult.getStatus() != SubmissionResult.Status.UNKNOWN) {
+      submissionResult = dataSource.getSubmissionResult(
+          submissionUrl, exercise, authentication, OffsetDateTime.MAX.toZonedDateTime());
+      var status = submissionResult.getStatus();
+      if (status != SubmissionResult.Status.WAITING && status != SubmissionResult.Status.UNKNOWN) {
         notifier.notifyAndHide(
             new FeedbackAvailableNotification(submissionResult, exercise), project);
-        PluginSettings.getInstance().getMainViewModel(project).setGradingDone(exercise);
         var courseProject = PluginSettings.getInstance().getCourseProject(project);
         if (courseProject != null) {
           courseProject.getExercisesUpdater().restart();

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/MainViewModel.java
@@ -1,7 +1,6 @@
 package fi.aalto.cs.apluscourses.presentation;
 
 import fi.aalto.cs.apluscourses.model.Authentication;
-import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.ExerciseGroup;
 import fi.aalto.cs.apluscourses.presentation.exercise.EmptyExercisesTreeViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
@@ -10,8 +9,6 @@ import fi.aalto.cs.apluscourses.utils.Event;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableProperty;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableReadWriteProperty;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -38,8 +35,6 @@ public class MainViewModel {
   @NotNull
   private final Options exerciseFilterOptions;
 
-  private Map<Long, Exercise> inGrading = new ConcurrentHashMap<>();
-
   /**
    * Instantiates a class representing the whole main view of the plugin.
    */
@@ -52,7 +47,6 @@ public class MainViewModel {
    * to {@link MainViewModel#exercisesViewModel}.
    */
   public void updateExercisesViewModel(@NotNull List<ExerciseGroup> exerciseGroups) {
-    inGrading.forEach((id, exercise) -> setInGrading(exerciseGroups, id));
     var viewModel = new ExercisesTreeViewModel(exerciseGroups, exerciseFilterOptions);
     viewModel.setAuthenticated(true);
     viewModel.setProjectReady(exercisesViewModel.get().isProjectReady());
@@ -71,39 +65,6 @@ public class MainViewModel {
   @NotNull
   public Options getExerciseFilterOptions() {
     return exerciseFilterOptions;
-  }
-
-  private static void setInGrading(List<ExerciseGroup> exerciseGroups, long id) {
-    exerciseGroups
-        .stream()
-        .map(ExerciseGroup::getExercises)
-        .filter(exercise -> exercise.containsKey(id))
-        .forEach(exercise -> exercise.get(id).setInGrading(true));
-  }
-
-  /**
-   * Modifies the 'inGrading' status of the exercise in 'exercisesViewModel' which corresponds to
-   * the given exercise (i.e. has the same ID). The given exercise is not modified. The observers of
-   * 'exercisesViewModel' are notified.
-   */
-  public void setSubmittedForGrading(@NotNull Exercise submittedForGrading) {
-    Exercise previous = inGrading.putIfAbsent(submittedForGrading.getId(), submittedForGrading);
-    if (previous == null) {
-      // This method gets called repeatedly by SubmissionStatusUpdater, so we check whether the
-      // entry was already there or not, and only update the tree if it wasn't there previously.
-      setInGrading(exercisesViewModel.get().getModel(), submittedForGrading.getId());
-      exercisesViewModel.valueChanged();
-    }
-  }
-
-  /**
-   * Marks the exercise with the ID of the given exercise as being graded. 'setSubmittedForGrading'
-   * must have been called with the same exercise ID previously. The given exercise is not modified.
-   */
-  public void setGradingDone(@NotNull Exercise submittedForGrading) {
-    // We don't call exercisesViewModel.valueChanged() to update the tree here.
-    // Once grading is done, the tree is updated anyways by SubmissionStatusUpdater.
-    inGrading.remove(submittedForGrading.getId());
   }
 
   /**

--- a/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.dal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.intellij.openapi.util.io.FileUtilRt;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Exercise;
@@ -60,10 +62,11 @@ public class APlusExerciseDataSourceTest {
 
   @Test
   public void testDefaultConstructor() {
-    APlusExerciseDataSource exerciseDataSource = new APlusExerciseDataSource(url);
+    var exerciseDataSource = new APlusExerciseDataSource(
+        url, Paths.get(FileUtilRt.getTempDirectory()));
     assertEquals(url, exerciseDataSource.getApiUrl());
-    assertSame(APlusExerciseDataSource.DefaultDataAccess.INSTANCE, exerciseDataSource.getClient());
-    assertSame(APlusExerciseDataSource.DefaultDataAccess.INSTANCE, exerciseDataSource.getParser());
+    assertTrue(exerciseDataSource.getClient() instanceof APlusExerciseDataSource.DefaultDataAccess);
+    assertTrue(exerciseDataSource.getParser() instanceof APlusExerciseDataSource.DefaultDataAccess);
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +33,7 @@ public class IntelliJCourseTest {
     String id = "id";
     String name = "testName";
     APlusProject project = mock(APlusProject.class);
+    doReturn(Paths.get("")).when(project).getBasePath();
     when(project.getMessageBus()).thenReturn(mock(MessageBus.class));
     CommonLibraryProvider commonLibraryProvider = new CommonLibraryProvider(project);
     IntelliJCourse course = new IntelliJCourse(id, name,
@@ -70,6 +72,7 @@ public class IntelliJCourseTest {
     Library library = new ModelExtensions.TestLibrary(libraryName);
 
     APlusProject project = mock(APlusProject.class);
+    doReturn(Paths.get("")).when(project).getBasePath();
     CommonLibraryProvider commonLibraryProvider = new CommonLibraryProvider(project) {
       @Nullable
       @Override
@@ -114,6 +117,9 @@ public class IntelliJCourseTest {
 
   @Test
   public void testGetComponentIfExists() {
+    var project = mock(APlusProject.class);
+    doReturn(Paths.get("")).when(project).getBasePath();
+
     String moduleName = "moominModule";
     VirtualFile file = mock(VirtualFile.class);
     when(file.getName()).thenReturn(moduleName);
@@ -140,7 +146,7 @@ public class IntelliJCourseTest {
         Collections.emptyMap(),
         //  courseVersion
         BuildInfo.INSTANCE.courseVersion,
-        mock(APlusProject.class),
+        project,
         mock(CommonLibraryProvider.class));
 
     assertSame(module, course.getComponentIfExists(file));
@@ -148,6 +154,9 @@ public class IntelliJCourseTest {
 
   @Test
   public void testGetComponentIfExistsReturnsNull() {
+    var project = mock(APlusProject.class);
+    doReturn(Paths.get("")).when(project).getBasePath();
+
     VirtualFile file1 = mock(VirtualFile.class);
     when(file1.getName()).thenReturn("someFile");
     when(file1.getPath()).thenReturn("somePath");
@@ -174,7 +183,7 @@ public class IntelliJCourseTest {
         Collections.emptyMap(),
         //  courseVersion
         BuildInfo.INSTANCE.courseVersion,
-        mock(APlusProject.class),
+        project,
         mock(CommonLibraryProvider.class));
 
     assertNull(course.getComponentIfExists(file1));

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -76,14 +76,6 @@ public class ExerciseTest {
         "Cool name", exercise.getName());
     assertEquals("The HTML URL is the same as the one in the JSON object",
         "http://localhost:1000", exercise.getHtmlUrl());
-    assertEquals("The submission IDs are read from the points object",
-        1L, exercise.getSubmissionResults().get(0).getId());
-    assertEquals("The submission IDs are read from the points object",
-        2L, exercise.getSubmissionResults().get(1).getId());
-    assertEquals("The submission points are read from the points object",
-        33, exercise.getSubmissionResults().get(0).getPoints());
-    assertEquals("The submission points are read from the points object",
-        44, exercise.getSubmissionResults().get(1).getPoints());
     assertEquals("The user points are read from the points object",
         10, exercise.getUserPoints());
     assertEquals("The max points is the same as the one in the JSON object",
@@ -193,4 +185,26 @@ public class ExerciseTest {
     assertFalse("Assignment isn't optional",
         notOptional.isOptional());
   }
+
+  @Test
+  public void testIsInGrading() {
+    var exercise = new Exercise(1, "", "http://localhost:1", 0, 10, 10, true);
+    exercise.addSubmissionResult(new SubmissionResult(
+        0, 0, SubmissionResult.Status.UNOFFICIAL, exercise
+    ));
+    assertFalse(exercise.isInGrading());
+    exercise.addSubmissionResult(new SubmissionResult(
+        1, 0, SubmissionResult.Status.GRADED, exercise
+    ));
+    assertFalse(exercise.isInGrading());
+    exercise.addSubmissionResult(new SubmissionResult(
+        2, 0, SubmissionResult.Status.UNKNOWN, exercise
+    ));
+    assertFalse(exercise.isInGrading());
+    exercise.addSubmissionResult(new SubmissionResult(
+        3, 0, SubmissionResult.Status.WAITING, exercise
+    ));
+    assertTrue(exercise.isInGrading());
+  }
+
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -63,7 +63,8 @@ public class ModelExtensions {
     @Override
     public SubmissionResult getSubmissionResult(@NotNull String submissionUrl,
                                                 @NotNull Exercise exercise,
-                                                @NotNull Authentication authentication) {
+                                                @NotNull Authentication authentication,
+                                                @NotNull ZonedDateTime minCacheEntryTime) {
       return new SubmissionResult(0, 20, SubmissionResult.Status.GRADED, exercise);
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -11,11 +11,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.intellij.openapi.project.Project;
 import fi.aalto.cs.apluscourses.intellij.notifications.FeedbackAvailableNotification;
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
+
+import java.time.ZonedDateTime;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class SubmissionStatusUpdaterTest {
 
   static class TestDataSource extends ModelExtensions.TestExerciseDataSource {
@@ -31,7 +35,8 @@ public class SubmissionStatusUpdaterTest {
     @Override
     public SubmissionResult getSubmissionResult(@NotNull String submissionUrl,
                                                 @NotNull Exercise exercise,
-                                                @NotNull Authentication authentication) {
+                                                @NotNull Authentication authentication,
+                                                @NotNull ZonedDateTime minCacheEntryTime) {
 
       return new SubmissionResult(
           123L,

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
@@ -58,7 +58,8 @@ public class ExerciseViewModelTest {
     Assert.assertEquals(ExerciseViewModel.Status.FULL_POINTS,
         new ExerciseViewModel(fullPoints).getStatus());
 
-    training.setInGrading(true);
+    training.addSubmissionResult(
+        new SubmissionResult(2L, 0, SubmissionResult.Status.WAITING, training));
     Assert.assertEquals(ExerciseViewModel.Status.IN_GRADING,
             new ExerciseViewModel(training).getStatus());
   }


### PR DESCRIPTION
# Description of the PR

This adds caching for A+ responses. It also uses the caching by downloading all submission results now from the API end point of an individual submission, which fixes the issue of incorrect statuses in submissions. The cache file can get relatively large, so there's some logic for doing IO in a background thread and combining multiple file writes when there's a burst of insertions into the cache.

~Beware in testing:
Loading the exercises initially will take some time, since it's doing quite many requests when no cache exists yet. There is no indication of progress, so it might appear as if the exercises are simply broken. As such, I would also consider this blocked by #609.~
Fixed by adding proxy objects, thanks to @OlliKiljunen for the idea

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [x] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [x] Yes.
- [x] Not yet. I will do it next.
- [x] Not relevant.
