### PR TITLE
Disable wrapping for toolbars

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/ExercisesView.form
@@ -10,7 +10,7 @@
     <children>
       <grid id="f02c8" binding="toolbarContainer" layout-manager="FlowLayout" hgap="0" vgap="0" flow-align="3">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="2" anchor="1" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="17"/>
           </grid>
         </constraints>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/module/ModulesView.form
@@ -12,7 +12,7 @@
     <children>
       <grid id="5c051" binding="toolbarContainer" layout-manager="FlowLayout" hgap="0" vgap="0" flow-align="3">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="1" hsize-policy="2" anchor="1" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="17"/>
           </grid>
         </constraints>


### PR DESCRIPTION
# Description of the PR

Now the toolbar action buttons don't get cut off

Before
![image](https://user-images.githubusercontent.com/34682147/118497546-d632d900-b72d-11eb-9fe2-e7ce0bf5e6b3.png)
After
![image](https://user-images.githubusercontent.com/34682147/118497451-c2877280-b72d-11eb-959d-eb4c343911bf.png)


# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [ ] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [x] Not yet. I will do it next.
- [x] Not relevant.
