### PR TITLE
Add editor as a highlightable component

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/EditorPresenter.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/EditorPresenter.java
@@ -5,13 +5,13 @@ import java.awt.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ProjectTreePresenter extends IntelliJComponentPresenterBase {
-  public ProjectTreePresenter(@NotNull String instruction, @NotNull String info) {
+public class EditorPresenter extends IntelliJComponentPresenterBase {
+  public EditorPresenter(@NotNull String instruction, @NotNull String info) {
     super(instruction, info);
   }
 
   @Override
   protected @Nullable Component getComponent() {
-    return ComponentDatabase.getProjectPane();
+    return ComponentDatabase.getEditorWindow();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJActivityFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJActivityFactory.java
@@ -35,6 +35,8 @@ public class IntelliJActivityFactory implements ActivityFactory {
     switch (component) {
       case "projectTree":
         return new ProjectTreePresenter(instruction, info);
+      case "editor":
+        return new EditorPresenter(instruction, info);
       default:
         throw new IllegalArgumentException("Unsupported component: " + component);
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
@@ -60,8 +60,7 @@ public class BalloonPopup extends JPanel {
     // the origin of the component that this popup is attached to must be converted to the
     // overlay pane's coordinate system, because that overlay uses a null layout and requires
     // that this popup specify its bounds
-    var componentWindowPos = SwingUtilities.convertPoint(
-        anchorComponent, anchorComponent.getX(), anchorComponent.getY(), getParent());
+    var componentWindowPos = SwingUtilities.convertPoint(anchorComponent, 0, 0, getParent());
 
     var maxSize = getMaximumSize();
     var prefSize = getPreferredSize();

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentDatabase.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentDatabase.java
@@ -1,0 +1,15 @@
+package fi.aalto.cs.apluscourses.ui.ideactivities;
+
+import java.awt.Component;
+import org.jetbrains.annotations.Nullable;
+
+public class ComponentDatabase {
+  public static @Nullable Component getProjectPane() {
+    Component component = ComponentLocator.getComponentByClass("ProjectViewPane");
+    return component == null ? null : component.getParent();
+  }
+
+  public static @Nullable Component getEditorWindow() {
+    return ComponentLocator.getComponentByClass("EditorWindow");
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentDatabase.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentDatabase.java
@@ -12,4 +12,8 @@ public class ComponentDatabase {
   public static @Nullable Component getEditorWindow() {
     return ComponentLocator.getComponentByClass("EditorWindow");
   }
+
+  private ComponentDatabase() {
+
+  }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentLocator.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/ComponentLocator.java
@@ -3,42 +3,54 @@ package fi.aalto.cs.apluscourses.ui.ideactivities;
 import com.intellij.util.concurrency.annotations.RequiresEdt;
 import java.awt.Component;
 import java.awt.Container;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ComponentLocator {
+  public static boolean isComponentOfClass(@NotNull Component c, @NotNull String classSubstring) {
+    return c.getClass().toString().contains(classSubstring);
+  }
+
+  public static boolean hasChildOfClass(@NotNull Container c, @NotNull String classSubstring) {
+    return !getComponents(c, comp -> isComponentOfClass(comp, classSubstring)).isEmpty();
+  }
+
   @RequiresEdt
-  private static @Nullable Component getComponentByClass(@NotNull Container parentComponent,
-                                                         @NotNull Predicate<Component> predicate) {
+  private static List<Component> getComponents(@NotNull Container parentComponent,
+                                               @NotNull Predicate<Component> predicate) {
+    List<Component> components = new ArrayList<>();
+
     for (var component : parentComponent.getComponents()) {
       if (predicate.test(component)) {
-        return component;
+        components.add(component);
       }
 
       // if a component is a Container, then it can contain more components and we should scan them
       if (component instanceof Container) {
-        var checkResult = getComponentByClass((Container) component, predicate);
-        if (checkResult != null) {
-          return checkResult;
-        }
+        var checkResult = getComponents((Container) component, predicate);
+        components.addAll(checkResult);
       }
     }
 
-    return null;
+    return components;
   }
 
   /**
-   * Scans through all components and locates the first one which class name matches a substring.
-   * @param componentClassSubstring A case-sensitive substring of the component's desired class.
+   * Scans through all components and locates the ones which class name matches a substring.
+   * @param classSubstring A case-sensitive substring of the component's desired class.
    */
   @RequiresEdt
-  public static @Nullable Component getComponentByClass(@NotNull String componentClassSubstring) {
-    Predicate<Component> predicate =
-        (c) -> c.getClass().toString().contains(componentClassSubstring);
+  public static List<Component> getComponentsByClass(@NotNull String classSubstring) {
+    return getComponents(JOptionPane.getRootFrame(), c -> isComponentOfClass(c, classSubstring));
+  }
 
-    return getComponentByClass(JOptionPane.getRootFrame(), predicate);
+  @RequiresEdt
+  public static @Nullable Component getComponentByClass(@NotNull String componentClassSubstring) {
+    return getComponentsByClass(componentClassSubstring).stream().findFirst().orElse(null);
   }
 
   private ComponentLocator() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
@@ -43,7 +43,7 @@ public class OverlayPane extends JPanel implements AWTEventListener {
     for (var c : exemptComponents) {
       // convertPoint is necessary because the component uses a different coordinate origin
       if (c.isShowing()) {
-        var windowPos = SwingUtilities.convertPoint(c, c.getX(), c.getY(), this);
+        var windowPos = SwingUtilities.convertPoint(c, 0, 0, this);
         var componentRect = new Rectangle(windowPos.x, windowPos.y, c.getWidth(), c.getHeight());
 
         overlayArea.subtract(new Area(componentRect));


### PR DESCRIPTION
# Description of the PR
Related to #638, but does not close it yet.

This PR:
- fixes a positioning bug (the new logic of using [0, 0] as the component origin was taken from IntelliJ's UI inspector, so it's safe to say that it is the correct way)
- adds the editor as a highlightable component (with the name "editor" in IDE activity configuration file)
- refactors ComponentLocator

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
