### PR TITLE
Multithreaded exercise fetching

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -13,6 +13,7 @@ import fi.aalto.cs.apluscourses.model.Points;
 import fi.aalto.cs.apluscourses.model.Submission;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
+import fi.aalto.cs.apluscourses.utils.ParallelDownloader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -130,6 +131,12 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   }
 
   @Override
+  public void prefetchExercise(long exerciseId, @NotNull Authentication authentication) {
+    var url = apiUrl + "exercises/" + exerciseId + "/";
+    ParallelDownloader.addUrlToQueue(url, authentication);
+  }
+
+  @Override
   @NotNull
   public Exercise getExercise(long exerciseId,
                               @NotNull Points points,
@@ -192,7 +199,7 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
       if (cacheEntry != null && cacheEntry.getCreationTime().compareTo(minCacheEntryTime) >= 0) {
         return cacheEntry.getValue();
       }
-      try (InputStream inputStream = CoursesClient.fetch(new URL(url), authentication)) {
+      try (InputStream inputStream = ParallelDownloader.getResponse(url, authentication)) {
         var response = new JSONObject(new JSONTokener(inputStream));
         cache.putValue(url, response);
         return response;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/ExercisesUpdater.java
@@ -77,6 +77,9 @@ public class ExercisesUpdater extends RepeatedTask {
         courseProject.setExerciseGroups(exerciseGroups);
         eventToTrigger.trigger();
       }
+
+      prefetchExercises(exerciseGroups, points, authentication);
+
       addExercises(exerciseGroups, points, authentication, progressViewModel, progress);
       progressViewModel.increment(progress);
       for (var exerciseGroup : exerciseGroups) {
@@ -106,6 +109,18 @@ public class ExercisesUpdater extends RepeatedTask {
         observable.valueChanged();
       }
       notifier.notify(new NetworkErrorNotification(e), courseProject.getProject());
+    }
+  }
+
+  private void prefetchExercises(@NotNull List<ExerciseGroup> exerciseGroups,
+                                 @NotNull Points points,
+                                 @NotNull Authentication authentication) {
+    var dataSource = courseProject.getCourse().getExerciseDataSource();
+
+    for (var exerciseGroup : exerciseGroups) {
+      for (var exerciseId : points.getExercises(exerciseGroup.getId())) {
+        dataSource.prefetchExercise(exerciseId, authentication);
+      }
     }
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
@@ -8,6 +8,9 @@ import org.jetbrains.annotations.Nullable;
 
 public interface ExerciseDataSource {
   @NotNull
+  String getApiUrl();
+
+  @NotNull
   List<Group> getGroups(@NotNull Course course, @NotNull Authentication authentication)
       throws IOException;
 
@@ -19,6 +22,8 @@ public interface ExerciseDataSource {
   @NotNull
   Points getPoints(@NotNull Course course, @NotNull Authentication authentication)
       throws IOException;
+
+  void prefetchExercise(long exerciseId, @NotNull Authentication authentication);
 
   @NotNull
   Exercise getExercise(long exerciseId,

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/ParallelDownloader.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/ParallelDownloader.java
@@ -1,0 +1,134 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import fi.aalto.cs.apluscourses.model.Authentication;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ParallelDownloader {
+
+  private static class DownloadRequest {
+    public final String url;
+    public final Authentication authentication;
+
+    private DownloadRequest(String url, Authentication authentication) {
+      this.url = url;
+      this.authentication = authentication;
+    }
+  }
+
+  private static class FileDownloadThread extends Thread {
+    private final DownloadRequest request;
+
+    public FileDownloadThread(DownloadRequest request) {
+      this.request = request;
+    }
+
+    @Override
+    public void run() {
+      try {
+        var response = CoursesClient.fetch(new URL(request.url), request.authentication);
+        synchronized (completedRequests) {
+          completedRequests.put(request.url, response);
+          completedRequests.notifyAll();
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private static class DownloadManagerThread extends Thread {
+
+    private final List<Thread> runningThreads = new ArrayList<>();
+
+    @Override
+    public void run() {
+      for (;;) {
+        synchronized (lock) {
+          DownloadRequest request;
+
+          while (runningThreads.size() <= 1 && (request = queuedUrls.poll()) != null) {
+            var t = new FileDownloadThread(request);
+            t.start();
+
+            runningThreads.add(t);
+          }
+
+          runningThreads.removeIf(x -> !x.isAlive());
+        }
+
+        try {
+          Thread.sleep(25);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+
+        if (Thread.interrupted()) {
+          return;
+        }
+      }
+    }
+  }
+
+  private static final Object lock = new Object();
+  private static final Event newResponse = new Event();
+
+  private static final ConcurrentHashMap<String, Object> x = new ConcurrentHashMap<String, Object>();
+  private static final Queue<DownloadRequest> queuedUrls = new ArrayDeque<>();
+  private static final ConcurrentHashMap<String, ByteArrayInputStream> completedRequests = new ConcurrentHashMap<>();
+
+  private static Thread downloadThread;
+
+  public static void addUrlToQueue(@NotNull String url, @Nullable Authentication authentication) {
+    synchronized (lock) {
+      System.err.println(url);
+      queuedUrls.add(new DownloadRequest(url, authentication));
+      x.put(url, 1);
+
+      if (downloadThread == null) {
+        downloadThread = new DownloadManagerThread();
+        downloadThread.start();
+      }
+    }
+  }
+
+  public static ByteArrayInputStream getResponse(@NotNull String url, @Nullable Authentication authentication) {
+    if (x.get(url) == null) {
+      try {
+        return CoursesClient.fetch(new URL(url), authentication);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    ByteArrayInputStream response = null;
+
+    for (;;) {
+      if ((response = completedRequests.get(url)) != null) {
+        completedRequests.remove(url);
+        return response;
+      }
+
+      synchronized (completedRequests) {
+        try {
+          completedRequests.wait();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+  
+  private ParallelDownloader() {
+    
+  }
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -24,6 +24,11 @@ public class ModelExtensions {
   }
 
   public static class TestExerciseDataSource implements ExerciseDataSource {
+    @Override
+    public @NotNull String getApiUrl() {
+      return "";
+    }
+
     @NotNull
     @Override
     public List<Group> getGroups(@NotNull Course course, @NotNull Authentication authentication) {
@@ -42,6 +47,11 @@ public class ModelExtensions {
     @Override
     public Points getPoints(@NotNull Course course, @NotNull Authentication authentication) {
       return new Points(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    @Override
+    public void prefetchExercise(long exerciseId, @NotNull Authentication authentication) {
+      // not used
     }
 
     @NotNull


### PR DESCRIPTION
# Description of the PR
Parallel download of exercises reduces initial loading time by a factor of a lot

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [x] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
