### PR TITLE
Force UTF-8 in JSON responses

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -22,6 +22,7 @@ import fi.aalto.cs.apluscourses.utils.CoursesClient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -261,7 +263,8 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
         return cacheEntry.getValue();
       }
       try (InputStream inputStream = CoursesClient.fetch(new URL(url), authentication)) {
-        var response = new JSONObject(new JSONTokener(inputStream));
+        var streamString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        var response = new JSONObject(new JSONTokener(streamString));
         cache.putValue(url, response);
         return response;
       }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -190,7 +191,7 @@ public abstract class Course implements ComponentSource {
       throws IOException, MalformedCourseConfigurationException {
     InputStream inputStream = CoursesClient.fetch(url);
     return Course.fromConfigurationData(
-        new InputStreamReader(inputStream), url.toString(), modelFactory);
+        new InputStreamReader(inputStream, StandardCharsets.UTF_8), url.toString(), modelFactory);
   }
 
   /**


### PR DESCRIPTION
# Description of the PR

By [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) section 8.1, JSON must be encoded as UTF-8. However this doesn't occur automatically for some reason (perhaps due to non-standard Content-Type header in A+ responses), so we enforce the proper encoding.

In practice, this used to be an issue only on Windows because AFAIK modern Linux distros use UTF-8 everywhere. Windows, however, uses language-specific code pages :(

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
