### PR TITLE
Shadow shadows

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
@@ -26,7 +26,7 @@ public class BalloonPopup extends JPanel {
     this.anchorComponent = anchorComponent;
 
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    setBorder(new EmptyBorder(JBUI.insets(0, 5, 10, 5)));
+    setBorder(new BalloonShadowBorder());
 
     // introduce a limit to the popup's width (so it doesn't take the entire screen width)
     setMaximumSize(new Dimension(500, 0));

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonPopup.java
@@ -14,7 +14,6 @@ import javax.swing.Icon;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EmptyBorder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,7 +34,8 @@ public class BalloonPopup extends JPanel implements TransparentComponent, MouseL
 
   private float transparencyCoefficient;
 
-  private static final int POPUP_MARGIN = 20;
+  public static final int BORDER_WIDTH = 6;
+  public static final int POPUP_MARGIN = 20;
 
   /**
    * Creates a popup with the given text. The popup is permanently attached to the specified
@@ -51,7 +51,7 @@ public class BalloonPopup extends JPanel implements TransparentComponent, MouseL
 
     setOpaque(false);
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    setBorder(new BalloonShadowBorder());
+    setBorder(new BalloonShadowBorder(BORDER_WIDTH, JBUI.insets(0, 5, 10, 5)));
 
     // introduce a limit to the popup's width (so it doesn't take the entire screen width)
     setMaximumSize(new Dimension(500, 0));
@@ -79,19 +79,19 @@ public class BalloonPopup extends JPanel implements TransparentComponent, MouseL
     return anchorComponent.isShowing();
   }
 
+  @SuppressWarnings("SuspiciousNameCombination")
   @Override
   protected void paintComponent(Graphics g) {
     super.paintComponent(g);
 
     Graphics g2 = g.create();
 
-    var bgColor = getBackground();
-    var newColor = new Color(bgColor.getRed(), bgColor.getGreen(), bgColor.getBlue(),
+    final var bgColor = getBackground();
+    final var newColor = new Color(bgColor.getRed(), bgColor.getGreen(), bgColor.getBlue(),
         (int) (transparencyCoefficient * 255));
 
     g2.setColor(newColor);
-    Rectangle drawBounds = g2.getClipBounds();
-    g2.fillRect(drawBounds.x, drawBounds.y, drawBounds.width, drawBounds.height);
+    g2.fillRect(BORDER_WIDTH, BORDER_WIDTH, getWidth() - BORDER_WIDTH * 2, getHeight() - BORDER_WIDTH * 2);
 
     g2.dispose();
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
@@ -1,24 +1,61 @@
 package fi.aalto.cs.apluscourses.ui.ideactivities;
 
 import com.intellij.util.ui.JBUI;
+import java.awt.BasicStroke;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Insets;
-import javax.swing.border.Border;
+import java.awt.RenderingHints;
+import javax.swing.border.AbstractBorder;
+import org.jetbrains.annotations.NotNull;
 
-public class BalloonShadowBorder implements Border {
-  @Override
-  public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+/**
+ * A border that works like EmptyBorder, except that it also paints a shadow
+ * outside of its default padding insets.
+ * The padding insets are normally drawn and highlighted. The shadow
+ * has a transparent background and is never highlighted.
+ */
+public class BalloonShadowBorder extends AbstractBorder {
+  private final int borderWidth;
 
+  private static final float MAX_SHADOW_ALPHA = 0.8f; // maximum opacity the shadow can reach (max: 1.0f)
+
+  @NotNull
+  private final Insets paddingInsets;
+
+  public BalloonShadowBorder(int width, @NotNull Insets paddingInsets) {
+    this.paddingInsets = paddingInsets;
+    borderWidth = width;
   }
 
   @Override
   public Insets getBorderInsets(Component c) {
-    return JBUI.insets(15, 15, 15, 15);
+    return JBUI.insets(
+        paddingInsets.top + borderWidth,
+        paddingInsets.left + borderWidth,
+        paddingInsets.bottom + borderWidth,
+        paddingInsets.right + borderWidth
+    );
   }
 
   @Override
   public boolean isBorderOpaque() {
     return false;
+  }
+
+  @Override
+  public void paintBorder(Component c, Graphics origGraphics, int x, int y, int width, int height) {
+    final var g = (Graphics2D) origGraphics.create();
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g.setStroke(new BasicStroke(1));
+
+    for (int i = 0; i < borderWidth; ++i) {
+      double alpha = ((i + 1.0f) / borderWidth) * MAX_SHADOW_ALPHA;
+      g.setColor(new Color(0, 0, 0, (float) Math.pow(alpha, 2.5)));
+
+      g.drawRoundRect(i, i, width - (i * 2), height - (i * 2), i * 2, i * 2);
+    }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
@@ -57,5 +57,7 @@ public class BalloonShadowBorder extends AbstractBorder {
 
       g.drawRoundRect(i, i, width - (i * 2), height - (i * 2), i * 2, i * 2);
     }
+
+    g.dispose();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/BalloonShadowBorder.java
@@ -1,0 +1,24 @@
+package fi.aalto.cs.apluscourses.ui.ideactivities;
+
+import com.intellij.util.ui.JBUI;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Insets;
+import javax.swing.border.Border;
+
+public class BalloonShadowBorder implements Border {
+  @Override
+  public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+
+  }
+
+  @Override
+  public Insets getBorderInsets(Component c) {
+    return JBUI.insets(15, 15, 15, 15);
+  }
+
+  @Override
+  public boolean isBorderOpaque() {
+    return false;
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
@@ -16,6 +16,7 @@ import java.awt.event.AWTEventListener;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.RoundRectangle2D;
 import java.util.HashSet;
 import java.util.Set;
 import javax.swing.JFrame;
@@ -61,7 +62,14 @@ public class OverlayPane extends JPanel implements AWTEventListener {
     for (var c : balloonPopups) {
       // popups are already places in the overlay's coordinate system
       if (c.isVisible()) {
-        var componentRect = new Rectangle(c.getX(), c.getY(), c.getWidth(), c.getHeight());
+        final int borderWidth = BalloonPopup.BORDER_WIDTH * 2;
+        final int borderHeight = BalloonPopup.BORDER_WIDTH * 2;
+
+        var componentRect = new RoundRectangle2D.Double(
+            c.getX() + BalloonPopup.BORDER_WIDTH, c.getY() + BalloonPopup.BORDER_WIDTH,
+            c.getWidth() - borderWidth, c.getHeight() - borderHeight, 6, 6
+        );
+
         overlayArea.subtract(new Area(componentRect));
       }
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ideactivities/OverlayPane.java
@@ -62,11 +62,12 @@ public class OverlayPane extends JPanel implements AWTEventListener {
     for (var c : balloonPopups) {
       // popups are already places in the overlay's coordinate system
       if (c.isVisible()) {
-        final int borderWidth = BalloonPopup.BORDER_WIDTH * 2;
-        final int borderHeight = BalloonPopup.BORDER_WIDTH * 2;
+        final double borderWidth = BalloonPopup.BORDER_WIDTH * 2.0;
+        final double borderHeight = BalloonPopup.BORDER_WIDTH * 2.0;
 
         var componentRect = new RoundRectangle2D.Double(
-            c.getX() + BalloonPopup.BORDER_WIDTH, c.getY() + BalloonPopup.BORDER_WIDTH,
+            c.getX() + (double) BalloonPopup.BORDER_WIDTH,
+            c.getY() + (double) BalloonPopup.BORDER_WIDTH,
             c.getWidth() - borderWidth, c.getHeight() - borderHeight, 6, 6
         );
 


### PR DESCRIPTION
# Description of the PR

Adds a shadow to balloon popups shown during IDE activities.
+ The "shadow" is a series of black RoundedRectangles with exponentially increasing transparency. It's a part of the BalloonPopup's border.
+ The shadow is NOT highlighted, and will never be. This means that, unless positioned on another component, it might hardly be visible. (It's not necessarily a bad thing, since a clear outline is visible.)
+ The border also has a padding that functions like EmptyBorder, and thanks to blending of the shadow into this padding area the BalloonPopup itself looks rounded as well.
+ ~~Also updated Kotlin version to silence Gradle's warnings.~~ didn't work

Gallery:
![obraz](https://user-images.githubusercontent.com/73069541/128644758-eece9ee2-e240-4d03-bb26-f5a20f8cdf19.png)
![obraz](https://user-images.githubusercontent.com/73069541/128644763-2b0a53e4-de0e-40aa-8c77-0be4fdffe067.png)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
