### PR TITLE
Removed logging of commonly thrown JSON exceptions

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManager.java
@@ -283,7 +283,7 @@ public class CourseFileManager {
     try {
       this.language = jsonObject.getString(LANGUAGE_KEY);
     } catch (JSONException e) {
-      logger.error("Course file missing language, defaulting to 'en'", e);
+      logger.warn("Course file missing language, defaulting to 'en'", e);
       language = "en";
     }
 
@@ -303,8 +303,7 @@ public class CourseFileManager {
       try {
         downloadedAt = ZonedDateTime.parse(moduleObject.getString(MODULE_DOWNLOADED_AT_KEY));
       } catch (JSONException e) {
-        logger
-            .error(String.format("Module %s missing 'downloadedAt' in course file", moduleName), e);
+        logger.warn(String.format("Module %s missing 'downloadedAt' in course file", moduleName), e);
         downloadedAt = Instant.EPOCH.atZone(ZoneId.systemDefault());
       }
 


### PR DESCRIPTION
# Description of the PR

A non-negligible number of users is experiencing exceptions in these two places. The plugin's functionality isn't really affected when these exceptions are thrown (because there are fallback values) but a message "IDE error occurred" is still shown due to the logger call.
This notification should be reserved only for serious issues, otherwise users will just ignore these IDE error notifications and not report actual problems.

Regarding as to why these exceptions are thrown: I'm not sure, but perhaps it happens when the user has updated the A+ Courses plugin and kept using the same project, which was created using a previous version?

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
