### PR TITLE
Ensure that window stays constant between tutorial steps

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJComponentPresenterBase.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJComponentPresenterBase.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.intellij.model.task;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.WindowManager;
 import com.intellij.util.concurrency.annotations.RequiresEdt;
 import fi.aalto.cs.apluscourses.model.task.CancelHandler;
 import fi.aalto.cs.apluscourses.model.task.ComponentPresenter;
@@ -12,6 +13,7 @@ import fi.aalto.cs.apluscourses.ui.ideactivities.OverlayPane;
 import java.util.Timer;
 import java.util.TimerTask;
 import javax.swing.Action;
+import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,6 +55,11 @@ public abstract class IntelliJComponentPresenterBase implements ComponentPresent
 
   @RequiresEdt
   private void highlightInternal() {
+    // if we are focused on another window than the tutorial one, don't touch anything
+    if (JOptionPane.getRootFrame() != WindowManager.getInstance().getFrame(project)) {
+      return;
+    }
+
     if (overlayPane == null) {
       overlayPane = OverlayPane.installOverlay();
     }


### PR DESCRIPTION
# Description of the PR
Stops tutorials from "invading" other IntelliJ windows within the same process. This is achieved by obtaining the current window object at tutorial start and executing the highlighting method (`highlightInternal`) only when the active window is the one that started the tutorial.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
