### PR TITLE
Gradle build fixed?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,14 +44,10 @@ dependencies {
 
 intellij {
     //  this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
-    version '212.4746'
+    version = '212.4746.92'
     updateSinceUntilBuild = false
-    plugins = ['java', 'org.intellij.scala:2021.2.15']
+    plugins = ['java', 'org.intellij.scala:2021.2.22']
     downloadRobotServerPlugin.version = remoteRobotVersion
-}
-
-patchPluginXml {
-    version.set(pluginVersion)
 }
 
 sourceSets {


### PR DESCRIPTION
# Description of the PR

+ This fixes the error we were seeing (`runIde` using latest EAP instead of the version specified). 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [ ] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
